### PR TITLE
Autoreload cooldown

### DIFF
--- a/js/auto-reload.js
+++ b/js/auto-reload.js
@@ -56,6 +56,13 @@ $(document).ready(function(){
 	$(window).focus(function() {
 		window_active = true;
 		recheck_activated();
+
+		// Reset the delay if needed
+		if(settings.get('reset_focus', true)) {
+			poll_interval_delay = end_of_page
+			    ? poll_interval_mindelay_bottom
+			    : poll_interval_mindelay_top;
+		}
 	});
 	$(window).blur(function() {
 		window_active = false;

--- a/js/settings.js
+++ b/js/settings.js
@@ -61,5 +61,7 @@ tb_settings['auto-reload'] = {
 	// Maximum delay before reloading the page
 	max_delay: 600000,
 	//Delay to wait before reloading when the user scrolls to the bottom
-	quick_delay: 100
+	quick_delay: 100,
+	// Reset the delay to the minimum upon focussing the window.
+	reset_focus: true
 };


### PR DESCRIPTION
Increase the auto-reload.js delay up to a maximum of 10 minutes when there are no posts for a while: handy for low-traffic boards.
