### PR TITLE
Fix unsanitised text vulnerability in post/fileinfo.html

### DIFF
--- a/templates/post/fileinfo.html
+++ b/templates/post/fileinfo.html
@@ -22,7 +22,7 @@
 			{% if config.show_filename and file.filename %}
 				, 
 				{% if file.filename|length > config.max_filename_display %}
-					<span class="postfilename" title="{{ file.filename|e }}">{{ file.filename|truncate_filename(config.max_filename_display)|bidi_cleanup }}</span>
+					<span class="postfilename" title="{{ file.filename|e|bidi_cleanup }}">{{ file.filename|truncate_filename(config.max_filename_display)|bidi_cleanup }}</span>
 				{% else %}
 					<span class="postfilename">{{ file.filename|e|bidi_cleanup }}</span>
 				{% endif %}


### PR DESCRIPTION
People could post small snippets of javascript, through filenames. Normally, filenames were sanitised, but in the case where they were too long (and so truncated), the original filename would be displayed, unsanitised, as the title attribute of the postfilename span.
