### PR TITLE
Fixed bumplock icon never displaying

### DIFF
--- a/templates/post_thread.html
+++ b/templates/post_thread.html
@@ -31,7 +31,7 @@
 			<img class="icon" title="Locked" src="{{ config.image_locked }}" alt="Locked" />
 		{% endif %}
 	{% endif %}
-	{% if post.bumplocked and (config.mod.view_bumplock < 0 or (post.mod and post.mod|hasPermission(config.mod.view_bumplock, board.uri))) %}
+	{% if post.sage and (config.mod.view_bumplock < 0 or (post.mod and post.mod|hasPermission(config.mod.view_bumplock, board.uri))) %}
 		{% if config.font_awesome %}
 			<i class="fa fa-anchor"></i>
 		{% else %}


### PR DESCRIPTION
`post.bumplocked` was wrongly checked instead of `post.sage`