### PR TITLE
Removed extra spaces between checkbox and label in options menu for consistency

### DIFF
--- a/js/forced-anon.js
+++ b/js/forced-anon.js
@@ -64,7 +64,7 @@ $(document).ready(function() {
         if (window.Options && Options.get_tab('general')) {
                 selector = '#forced-anon';
                 event = 'change';
-                Options.extend_tab("general", "<label id='forced-anon'><input type='checkbox' /> "+_('Forced anonymity')+"</label>");
+                Options.extend_tab("general", "<label id='forced-anon'><input type='checkbox' />"+_('Forced anonymity')+"</label>");
         }
         else {
                 selector = '#forced-anon';

--- a/js/no-animated-gif.js
+++ b/js/no-animated-gif.js
@@ -57,7 +57,7 @@ if (active_page == 'thread' || active_page == 'index' || active_page == 'ukko' |
 		if (window.Options && Options.get_tab('general')) {
 			selector = '#no-animated-gif>input';
 			event = 'change';
-			Options.extend_tab("general", "<label id='no-animated-gif'><input type='checkbox' /> "+_('Unanimate GIFs')+"</label>");
+			Options.extend_tab("general", "<label id='no-animated-gif'><input type='checkbox' />"+_('Unanimate GIFs')+"</label>");
 		}
 		else {
 			selector = '#no-animated-gif';

--- a/js/toggle-images.js
+++ b/js/toggle-images.js
@@ -60,7 +60,7 @@ $(document).ready(function(){
         if (window.Options && Options.get_tab('general')) {  
                 selector = '#toggle-images>input';
                 event = 'change';
-                Options.extend_tab("general", "<label id='toggle-images'><input type='checkbox' /> "+_('Hide images')+"</label>");
+                Options.extend_tab("general", "<label id='toggle-images'><input type='checkbox' />"+_('Hide images')+"</label>");
         }
         else {
                 selector = '#toggle-images a';


### PR DESCRIPTION
Some options had a space between the checkbox and the label while some others didn't. The spaces were removed so all of the options would look the same.