### PR TITLE
Added space after Google image search link

### DIFF
--- a/templates/post/image_identification.html
+++ b/templates/post/image_identification.html
@@ -8,7 +8,7 @@
 			<a href="http://regex.info/exif.cgi?url={{ config.domain }}{{ config.uri_img }}{{ file.file }}" target="_blank">Exif</a> 
 		{% endif %}
 		{% if config.image_identification_google %}
-			<a href="https://www.google.com/searchbyimage?image_url={{ config.domain }}{{ config.uri_img }}{{ file.file }}" target="_blank">Google</a>
+			<a href="https://www.google.com/searchbyimage?image_url={{ config.domain }}{{ config.uri_img }}{{ file.file }}" target="_blank">Google</a> 
 		{% endif %}
 		{% if config.image_identification_iqdb %}
 			<a href="http://iqdb.org/?url={{ config.domain }}{{ config.uri_img }}{{ file.file }}" target="_blank">iqdb</a>


### PR DESCRIPTION
Previous links had a space after them but this one didn't. Fixes there being no space between Google and iqdb links.