### PR TITLE
Removed tab at start of api.php to fix ban list and possibly other stuff

### DIFF
--- a/inc/api.php
+++ b/inc/api.php
@@ -1,4 +1,4 @@
-	<?php
+<?php
 /*
  *  Copyright (c) 2010-2013 Tinyboard Development Group
  */


### PR DESCRIPTION
This was causing an empty ban list for me, so I probably wasn't the only one. Not sure if it was also messing up anything else.