### PR TITLE
Make mod/recent_posts.html respect $config['dir']['res']

### DIFF
--- a/templates/mod/recent_posts.html
+++ b/templates/mod/recent_posts.html
@@ -11,7 +11,7 @@
 		{% else %}
 			{% set thread = post.thread %}
 		{% endif %}
-		<div class="post-wrapper" data-board="{{ post.board }}"><hr/><a class="eita-link" id="eita-{{ post.board }}-{{ thread }}" href="?/{{ post.board }}/res/{{ thread }}.html#{{ post.id }}">/{{ post.board }}/{{ post.id }}</a><br>
+		<div class="post-wrapper" data-board="{{ post.board }}"><hr/><a class="eita-link" id="eita-{{ post.board }}-{{ thread }}" href="?/{{ post.board }}/{{ config.dir.res }}{{ thread }}.html#{{ post.id }}">/{{ post.board }}/{{ post.id }}</a><br>
 			{{ post.built }}
 		</div>
 	{% endfor %}


### PR DESCRIPTION
![Image](https://i.imgur.com/ZuUvIdb.png)
So these links in mod.php?/recent/25 don't keep linking to /board/res/postnumber despite any changes to $config['dir']['res'] e.g. changing res/ to thread/