### PR TITLE
Rebuild index when mod deletes a thread.

### DIFF
--- a/inc/mod/pages.php
+++ b/inc/mod/pages.php
@@ -1721,6 +1721,8 @@ function mod_deletebyip($boardName, $post, $global = false) {
 		deletePost($post['id'], false, false);
 
 		rebuildThemes('post-delete', $board['uri']);
+		
+		buildIndex();
 
 		if ($post['thread'])
 			$threads_to_rebuild[$post['board']][$post['thread']] = true;


### PR DESCRIPTION
The index does not properly rebuild when a mod deletes a thread, resulting in a ghost thread remaining in the index until the next rebuild. This fix was originally contributed to Uboachan's codebase by Mannosuke.