### PR TITLE
Fixed XSS in post edit page and modsearch

### DIFF
--- a/templates/mod/edit_post_form.html
+++ b/templates/mod/edit_post_form.html
@@ -7,7 +7,7 @@
 				{% trans %}Name{% endtrans %}
 			</th>
 			<td>
-				<input type="text" name="name" size="25" maxlength="35" autocomplete="off" value="{{ post.name }}">
+				<input type="text" name="name" size="25" maxlength="35" autocomplete="off" value="{{ post.name|e }}">
 			</td>
 		</tr>
 		<tr>
@@ -23,7 +23,7 @@
 				{% trans %}Subject{% endtrans %}
 			</th>
 			<td>
-				<input style="float:left;" type="text" name="subject" size="25" maxlength="100" autocomplete="off" value="{{ post.subject }}">
+				<input style="float:left;" type="text" name="subject" size="25" maxlength="100" autocomplete="off" value="{{ post.subject|e }}">
 				<input accesskey="s" style="margin-left:2px;" type="submit" name="post" value="{% trans %}Update{% endtrans %}">
 			</td>
 		</tr>

--- a/templates/mod/search_results.html
+++ b/templates/mod/search_results.html
@@ -224,7 +224,7 @@
 							<a class="email" href="mailto:{{ post.email }}">
 						{% endif %}
 						{% set capcode = post.capcode|capcode %}
-						<span {% if capcode.name %}style="{{ capcode.name }}" {% endif %}class="name">{{ post.name }}</span>
+						<span {% if capcode.name %}style="{{ capcode.name }}" {% endif %}class="name">{{ post.name|e }}</span>
 						{% if post.trip|length > 0 %}
 							<span {% if capcode.trip %}style="{{ capcode.trip }}" {% endif %}class="trip">{{ post.trip }}</span>
 						{% endif %}
@@ -239,7 +239,7 @@
 				</td>
 				<td style="max-width:250px">
 					{% if post.subject %}
-						<small>{{ post.subject }}</small>
+						<small>{{ post.subject|e }}</small>
 					{% else %}
 						&ndash;
 					{% endif %}


### PR DESCRIPTION
Name and subject inputs are not being escaped at post editing page (**/mod.php?/b/edit/**) and at the modsearch page (**/mod.php?/search/posts/**).
This commit adds twig's escaping to templates of the pages affected.

**1. Post editing**
![xss1](https://cloud.githubusercontent.com/assets/5060004/26287019/9e572cfa-3e48-11e7-9781-2b0ca6f22a8f.png)
Edit page of a post that was made with html in the name or the subject input.

**2. Modsearch**
![xss2](https://cloud.githubusercontent.com/assets/5060004/26287074/e5a4eb0a-3e49-11e7-8d4b-9efef5f929f9.png)
Results of a search with a post that has html in name input.

Note that the email input does not need to be escaped because it is saved with htmlspecialchars().