### PR TITLE
Bugfixes: edit post page minor fix and install.php bug

### DIFF
--- a/inc/mod/pages.php
+++ b/inc/mod/pages.php
@@ -1547,7 +1547,7 @@ function mod_edit_post($board, $edit_raw_html, $postID) {
 		else
 			$query = prepare(sprintf('UPDATE ``posts_%s`` SET `name` = :name, `email` = :email, `subject` = :subject, `body_nomarkup` = :body WHERE `id` = :id', $board));
 		$query->bindValue(':id', $postID);
-		$query->bindValue('name', $_POST['name']);
+		$query->bindValue(':name', $_POST['name']);
 		$query->bindValue(':email', $_POST['email']);
 		$query->bindValue(':subject', $_POST['subject']);
 		$query->bindValue(':body', $_POST['body']);

--- a/install.php
+++ b/install.php
@@ -900,6 +900,10 @@ if ($step == 0) {
 	$instance_config .= "\n";
 	
 	if (@file_put_contents('inc/instance-config.php', $instance_config)) {
+		// flushes opcache if php >= 5.5.0 or opcache is installed via PECL
+		if (function_exists('opcache_invalidate')) {
+			opcache_invalidate('inc/instance-config.php');
+		}
 		header('Location: ?step=4', true, $config['redirect_http']);
 	} else {
 		$page['title'] = 'Manual installation required';


### PR DESCRIPTION
The cause of issue #229 is that config-instance.php file was cache by opcache.
This PR fixes it by adding opcache flushing if opcache is installed, as it is installed by default at PHP >= 5.5.0.