### PR TITLE
Use random_bytes if PHP version >= 7.1.0

### DIFF
--- a/inc/mod/auth.php
+++ b/inc/mod/auth.php
@@ -69,7 +69,13 @@ function test_password($password, $salt, $test) {
 }
 
 function generate_salt() {
-	// 128 bits of entropy
+	// mcrypt_create_iv() was deprecated in PHP 7.1.0, only use it if we're below that version number.
+	if (PHP_VERSION_ID < 701000) {
+		// 128 bits of entropy
+		return strtr(base64_encode(mcrypt_create_iv(16, MCRYPT_DEV_URANDOM)), '+', '.');
+	}
+
+	// Otherwise, use random_bytes()
 	return strtr(base64_encode(random_bytes(16)), '+', '.');
 }
 

--- a/inc/mod/auth.php
+++ b/inc/mod/auth.php
@@ -70,7 +70,7 @@ function test_password($password, $salt, $test) {
 
 function generate_salt() {
 	// 128 bits of entropy
-	return strtr(base64_encode(mcrypt_create_iv(16, MCRYPT_DEV_URANDOM)), '+', '.');
+	return strtr(base64_encode(random_bytes(16)), '+', '.');
 }
 
 function login($username, $password) {

--- a/inc/mod/auth.php
+++ b/inc/mod/auth.php
@@ -70,7 +70,7 @@ function test_password($password, $salt, $test) {
 
 function generate_salt() {
 	// mcrypt_create_iv() was deprecated in PHP 7.1.0, only use it if we're below that version number.
-	if (PHP_VERSION_ID < 701000) {
+	if (PHP_VERSION_ID < 70100) {
 		// 128 bits of entropy
 		return strtr(base64_encode(mcrypt_create_iv(16, MCRYPT_DEV_URANDOM)), '+', '.');
 	}


### PR DESCRIPTION
According to the [`mcrypt_create_iv()`](https://secure.php.net/manual/en/function.mcrypt-create-iv.php) documentation, the function was deprecated in PHP 7.1.0. It is recommended to use [`random_bytes()`](https://secure.php.net/manual/en/function.random-bytes.php) to replace `mcrypt_create_iv()`.

Since `random_bytes()` isn't present in PHP 5, I've implemented a version check to use `mcrypt_create_iv()` if the server is running a PHP version where the function isn't deprecated.

Because of the deprecation, mods are unable to log in to `mod.php` because a deprecation error is thrown. this pull fixes that issue.