### PR TITLE
Fix Capitalization on setUpControl for Chromium

### DIFF
--- a/js/webm-settings.js
+++ b/js/webm-settings.js
@@ -68,7 +68,7 @@ function refreshSettings() {
     }
 }
 
-function setupControl(control) {
+function setUpControl(control) {
     if (control.addEventListener) control.addEventListener("change", function(e) {
         if (control.type == "checkbox") {
             changeSetting(control.name, control.checked);
@@ -81,7 +81,7 @@ function setupControl(control) {
 refreshSettings();
 var settingsItems = settingsMenu.getElementsByTagName("input");
 for (var i = 0; i < settingsItems.length; i++) {
-    setupControl(settingsItems[i]);
+    setUpControl(settingsItems[i]);
 }
 
 if (settingsMenu.addEventListener && !window.Options) {


### PR DESCRIPTION
Chromium browsers expect capital U in setUpControl and old version of webm-settings.js has setupControl which causes a error and makes expand-video.js not work and options.js not save when this is in use. This bug is not present on FireFox which automatically fixes this for some reason. No lines actually added or removed.