### PR TITLE
Fix wrong variable used in ban lookup

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -930,7 +930,7 @@ function checkBan($board = false) {
 	}
 
 	foreach ($ips as $ip) {
-		$bans = Bans::find($_SERVER['REMOTE_ADDR'], $board, $config['show_modname']);
+		$bans = Bans::find($ip, $board, $config['show_modname']);
 	
 		foreach ($bans as &$ban) {
 			if ($ban['expires'] && $ban['expires'] < time()) {


### PR DESCRIPTION
` $_SERVER['REMOTE_ADDR']` is hardcoded in ban lookup instead of `$ip` variable