### PR TITLE
insignificant fix

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -401,7 +401,7 @@ function define_groups() {
 	foreach ($config['mod']['groups'] as $group_value => $group_name) {
 		$group_name = strtoupper($group_name);
 		if(!defined($group_name)) {
-			define($group_name, $group_value, true);
+			define($group_name, $group_value);
 		}
 	}
 	


### PR DESCRIPTION
PHP7 shows a warning when executing tools/rebuild2.php: "Declaration of case-insensitive constants is deprecated"
$group_name and $group_value really not need be case-insensitive, so i simply removed that "true".