### PR TITLE
Fix for title/subtitle related issue on Ukko theme

### DIFF
--- a/templates/themes/ukko/theme.php
+++ b/templates/themes/ukko/theme.php
@@ -31,8 +31,8 @@
 			$overflow = array();
 			$board = array(
 				'url' => $this->settings['uri'],
-				'name' => $this->settings['title'],
-				'title' => sprintf($this->settings['subtitle'], $this->settings['thread_limit'])
+				'title' => $this->settings['title'],
+				'subtitle' => sprintf($this->settings['subtitle'], $this->settings['thread_limit'])
 			);
 
 			$query = '';


### PR DESCRIPTION
'subtitle' was used as the page title and 'title' was unused.