### PR TITLE
Fix custom thumb_ext when using ImageMagick convert

### DIFF
--- a/inc/image.php
+++ b/inc/image.php
@@ -311,7 +311,7 @@ class ImageConvert extends ImageBase {
 			$this->destroy();
 		}
 		
-		$this->temp = tempnam($config['tmp'], 'convert') . ($config['thumb_ext'] == '' ? '.' . $config['thumb_ext'] : '');
+		$this->temp = tempnam($config['tmp'], 'convert') . ($config['thumb_ext'] == '' ? '' : '.' . $config['thumb_ext']);
 		
 		$config['thumb_keep_animation_frames'] = (int)$config['thumb_keep_animation_frames'];
 		

--- a/inc/image.php
+++ b/inc/image.php
@@ -311,8 +311,8 @@ class ImageConvert extends ImageBase {
 			$this->destroy();
 		}
 		
-		$this->temp = tempnam($config['tmp'], 'convert');
-				
+		$this->temp = tempnam($config['tmp'], 'convert') . ($config['thumb_ext'] == '' ? '.' . $config['thumb_ext'] : '');
+		
 		$config['thumb_keep_animation_frames'] = (int)$config['thumb_keep_animation_frames'];
 		
 		if ($this->format == 'gif' && ($config['thumb_ext'] == 'gif' || $config['thumb_ext'] == '') && $config['thumb_keep_animation_frames'] > 1) {


### PR DESCRIPTION
When using ImageMagick's convert tool, the output defaults to the input format if no file extension or format is specified.
The temp file currently has no extension, so a $config['thumb_ext'] value has no effect on the image.
By appending the thumb_ext to the temp output file, it will convert the image to the intended format.

You can see this issue present on lainchan, where thumbnails have a .png filename but are not really PNG files when the input is a .jpg, for example.