### PR TITLE
Fix redis 'delete' deprecation error

### DIFF
--- a/inc/cache.php
+++ b/inc/cache.php
@@ -118,10 +118,14 @@ class Cache {
 		
 		switch ($config['cache']['enabled']) {
 			case 'memcached':
-			case 'redis':
 				if (!self::$cache)
 					self::init();
 				self::$cache->delete($key);
+				break;
+			case 'redis':
+				if (!self::$cache)
+					self::init();
+				self::$cache->del($key);
 				break;
 			case 'apc':
 				apc_delete($key);


### PR DESCRIPTION
Redis deprecated the 'delete' alias for 'del'. Posting while using redis cache would return an error, the post would still be posted.