### PR TITLE
Fixed broken query in posts.php preventing posts from being created if there's a table prefix

### DIFF
--- a/post.php
+++ b/post.php
@@ -1212,7 +1212,7 @@ if (isset($_POST['delete'])) {
 	if (!$post['mod']) header('X-Associated-Content: "' . $redirect . '"');
 
 	// Any telegrams to show?
-	$query = prepare('SELECT * FROM ``telegrams`` WHERE ``ip`` = :ip AND ``seen`` = 0');
+	$query = prepare('SELECT * FROM ``telegrams`` WHERE `ip` = :ip AND `seen` = 0');
 	$query->bindValue(':ip', $_SERVER['REMOTE_ADDR']);
 	$query->execute() or error(db_error($query));
 	$telegrams = $query->fetchAll(PDO::FETCH_ASSOC);


### PR DESCRIPTION
On a fresh instance of vichan, I was unable to create a new post on the default board without an error appearing about the column "[myprefix]_ip" not existing. I looked at the code and noticed one specific query using double ticks for columns (\`\`column\`\`) while every other query was using single ticks (\`column\`). Being unfamiliar with PHP, I naively changed it to use single ticks, and the problem was solved.