### PR TITLE
Enable download with filename without JavaScript

### DIFF
--- a/templates/post/fileinfo.html
+++ b/templates/post/fileinfo.html
@@ -20,12 +20,13 @@
 				{% endif %}
 			{% endif %}
 			{% if config.show_filename and file.filename %}
-				, 
+				, <span class="postfilename"><a href="{{ config.uri_img }}{{ file.file|e|bidi_cleanup }}" download="{{ file.filename|e|bidi_cleanup }}"
 				{% if file.filename|length > config.max_filename_display %}
-					<span class="postfilename" title="{{ file.filename|e|bidi_cleanup }}">{{ file.filename|truncate_filename(config.max_filename_display)|e|bidi_cleanup }}</span>
+					title="Save as original filename: {{ file.filename|e|bidi_cleanup }}">{{ file.filename|truncate_filename(config.max_filename_display)|e|bidi_cleanup }}
 				{% else %}
-					<span class="postfilename">{{ file.filename|e|bidi_cleanup }}</span>
+					title="Save as original filename">{{ file.filename|e|bidi_cleanup }}
 				{% endif %}
+				</a></span>
 			{% endif %}
 		)
 		{% include "post/image_identification.html" %}


### PR DESCRIPTION
This enables the functionality of download-original.js for non-JS users.