### PR TITLE
Fix editing global pages for 7.4

### DIFF
--- a/inc/mod/pages.php
+++ b/inc/mod/pages.php
@@ -2800,7 +2800,7 @@ function mod_edit_page($id) {
 		$query->bindValue(':id', $id);
 		$query->execute() or error(db_error($query));
 
-		$fn = ($board['uri'] ? ($board['uri'] . '/') : '') . $page['name'] . '.html';
+		$fn = (isset($board['uri']) ? ($board['uri'] . '/') : '') . $page['name'] . '.html';
 		$body = "<div class='ban'>$write</div>";
 		$html = Element('page.html', array('config' => $config, 'boardlist' => createBoardlist(), 'body' => $body, 'title' => utf8tohtml($page['title'])));
 		file_write($fn, $html);


### PR DESCRIPTION
When trying to edit a global page, you click 'save' and get this:

![image](https://user-images.githubusercontent.com/35663391/151471346-32982c45-e6b2-431a-a3b0-c81446f43e18.png)

This is a common issue, caused by stricter formatting of 7.4. 

Reference: https://stackoverflow.com/questions/59336951/message-trying-to-access-array-offset-on-value-of-type-null

Simply adding `isset()` to the check of a board URI fixes the issue.