### PR TITLE
Replaces the Google reCAPTCHA API's domain

### DIFF
--- a/post.php
+++ b/post.php
@@ -401,7 +401,7 @@ if (isset($_POST['delete'])) {
 				error($config['error']['bot']);	
 
 			// Check what reCAPTCHA has to say...
-			$resp = json_decode(file_get_contents(sprintf('https://www.google.com/recaptcha/api/siteverify?secret=%s&response=%s&remoteip=%s',
+			$resp = json_decode(file_get_contents(sprintf('https://www.recaptcha.net/recaptcha/api/siteverify?secret=%s&response=%s&remoteip=%s',
 				$config['recaptcha_private'],
 				urlencode($_POST['g-recaptcha-response']),
 				$_SERVER['REMOTE_ADDR'])), true);

--- a/templates/header.html
+++ b/templates/header.html
@@ -17,7 +17,7 @@
 			{% for javascript in config.additional_javascript %}<script type="text/javascript" src="{{ config.additional_javascript_url }}{{ javascript }}"></script>{% endfor %}
 			{% endif %}
 		{% endif %}
-		{% if config.recaptcha %}<script src="//www.google.com/recaptcha/api.js"></script>
+		{% if config.recaptcha %}<script src="//www.recaptcha.net/recaptcha/api.js"></script>
 		<style type="text/css">{% verbatim %}
 			#recaptcha_area {
 				float: none !important;


### PR DESCRIPTION
Google provides Google reCAPTCHA endpoints via www.google.com by default. This means that Google reCAPTCHA is not available in some regions, such as the Chinese mainland.

So Google deploys [the same endpoints](https://www.recaptcha.net/recaptcha/api.js) at www.recaptcha.net.

www.recaptcha.net has access to servers in the Chinese mainland in addition to the regular global CDN. So it is a better choice than www.google.com.