### PR TITLE
Fix undefined error when captcha has expired

### DIFF
--- a/securimage.php
+++ b/securimage.php
@@ -56,8 +56,9 @@ switch ($mode) {
 
 		$ary = $query->fetchAll();
 
-		if (!$ary) {
+		if (!$ary) { // captcha expired
 			echo "0";
+			break;
 		} else {
 			$query = prepare("DELETE FROM `captchas` WHERE `cookie` = ? AND `extra` = ?");
 			$query->execute([$_GET['cookie'], $_GET['extra']]);


### PR DESCRIPTION
When a captcha is expired, the code doesn't have a break to avoid going on to the verification causing an error at line 66 because `$ary` doesn't exists https://github.com/vichan-devel/vichan/blob/c8f88c14a8aa87c51318554752f059d9b7ed2711/securimage.php#L66