### PR TITLE
Caching the individual banners.

### DIFF
--- a/b.php
+++ b/b.php
@@ -3,17 +3,9 @@ $dir = "static/banners/";
 $files = scandir($dir);
 $images = array_diff($files, array('.', '..'));
 $name = $images[array_rand($images)];
-// open the file in a binary mode
-$fp = fopen($dir . $name, 'rb');
+$image = $dir . $name;
+header("Location: " . $image, true, 302);	
 
-// send the right headers
-header('Cache-Control: no-cache, no-store, must-revalidate'); // HTTP 1.1
-header('Pragma: no-cache'); // HTTP 1.0
-header('Expires: 0'); // Proxies
-header('Content-Type: ' . $fp['type']);
-header('Content-Length: ' . $fp['bytes']);
+exit();
 
-// dump the picture and stop the script
-fpassthru($fp);
-exit;
 ?>


### PR DESCRIPTION
The banner script is wasteful imo. I don't think the server should read the image file every single page anyone opens, and I don't think it should send the file over and over either wasting data.

- Prevents loading the same 1mb gif a bazillion times by redirecting the <img> to an actual image file that can be cached in visitors computer.
- Still random every load