### PR TITLE
When moving Reply from Thread to Thread: Remove re-direct to error page "Thread does not exist"

### DIFF
--- a/inc/mod/pages.php
+++ b/inc/mod/pages.php
@@ -1257,9 +1257,11 @@ function mod_move_reply($originBoard, $postID) {
 
 		// build index
 		buildIndex();
-		// build new thread
-		buildThread($newID);
-		
+		if ($post['op']) {
+			// build new thread
+			buildThread($newID);
+		}
+
 		// trigger themes
 		rebuildThemes('post', $targetBoard);
 		// mod log


### PR DESCRIPTION
Add condition (post is Thread) before trying to Build Thread for a moved Post

Now after clicking "Move" on a reply, and moving it to another thread, it re-directs to the target thread, instead of the error page.