### PR TITLE
fix "scandir should not need to sort in b.php (banner code)"

### DIFF
--- a/b.php
+++ b/b.php
@@ -1,6 +1,6 @@
 <?php
 $dir = "static/banners/";
-$files = scandir($dir);
+$files = scandir($dir, SCANDIR_SORT_NONE);
 $images = array_diff($files, array('.', '..'));
 $name = $images[array_rand($images)];
 // open the file in a binary mode


### PR DESCRIPTION
scandir by default sorts files in ascending order. this is unnecessary when you're picking a random file anyway. it's just wasting CPU cycles and increasing latency as more files are added.

currently it is

    $files = scandir($dir);

it should be

    $files = scandir($dir, SCANDIR_SORT_NONE);