### PR TITLE
Add default value for flood_cache

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -466,7 +466,9 @@
 	// outside the current board. This means that if you have a special flood condition for a specific board
 	// (contained in a board configuration file) which has a flood-time greater than any of those in the
 	// global configuration, you need to set the following variable to the maximum flood-time condition value.
+	// Set to -1 to disable.
 	// $config['flood_cache'] = 60 * 60 * 24; // 24 hours
+	$config['flood_cache'] = -1;
 
 /*
  * ====================

--- a/inc/filters.php
+++ b/inc/filters.php
@@ -192,7 +192,7 @@ function purge_flood_table() {
 	// aware of flood filters in other board configurations. You can solve this problem by settings the
 	// config variable $config['flood_cache'] (seconds).
 	
-	if (isset($config['flood_cache'])) {
+	if ($config['flood_cache'] != -1) {
 		$max_time = &$config['flood_cache'];
 	} else {
 		$max_time = 0;


### PR DESCRIPTION
The original code left flood_cache undefined, leading to errors in newer versions of PHP. 

Closes https://github.com/vichan-devel/vichan/issues/525.