### PR TITLE
fix: checking correct name for ban_length while editing a ban 

### DIFF
--- a/inc/mod/pages.php
+++ b/inc/mod/pages.php
@@ -979,8 +979,8 @@ function mod_edit_ban($ban_id) {
 		else
 			$new_ban['reason'] = $args['bans'][0]['reason'];
 
-		if (isset($_POST['ban_length']) && !empty($_POST['ban_length']))
-			$new_ban['length'] = $_POST['ban_length'];
+		if (isset($_POST['length']) && !empty($_POST['length']))
+			$new_ban['length'] = $_POST['length'];
 		else
 			$new_ban['length'] = false;
 


### PR DESCRIPTION
wrong post variable is being checked in pages.php. related: b02a1fc0dbecba10074e436745b16b6f091a6a74