### PR TITLE
Fix post number on dismissed reports log, show id

### DIFF
--- a/inc/mod/pages.php
+++ b/inc/mod/pages.php
@@ -2433,7 +2433,7 @@ function mod_report_dismiss($id, $all = false) {
 	if ($all)
 		modLog("Dismissed all reports by <a href=\"?/IP/$cip\">$cip</a>");
 	else
-		modLog("Dismissed a report for post #{$id}", $board);
+		modLog("Dismissed a report for post #{$post} <small>(#{$id})</small>", $board);
 	
 	header('Location: ?/reports', true, $config['redirect_http']);
 }


### PR DESCRIPTION
Currently a dismissed report only shows the report id instead of the post number which was reported. This update changes the log from the bottom example to the top:

![image](https://user-images.githubusercontent.com/83621080/212593265-3cdbb4fc-ee18-42f2-84c6-ac8b0e28a87a.png)
