### PR TITLE
Fix combining character set, allow limit for combining characters

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -485,8 +485,11 @@
 
 	// Strip superfluous new lines at the end of a post.
 	$config['strip_superfluous_returns'] = true;
-	// Strip combining characters from Unicode strings (eg. "Zalgo").
+	/// Strip combining characters from Unicode strings (eg. "Zalgo").  This will impact some non-English languages.
 	$config['strip_combining_chars'] = true;
+    // Maximum number of combining characters in a row allowed in Unicode strings so that they can still be used in moderation.
+    // Requires $config['strip_combining_chars'] = true;
+    $config['max_combining_chars'] = 3;
 
 	// Maximum post body length.
 	$config['max_body'] = 1800;

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -2330,19 +2330,11 @@ function ordutf8($string, &$offset) {
 	return $code;
 }
 
+// Limit Non_Spacing_Mark and Enclosing_Mark characters
 function strip_combining_chars($str) {
-	$chars = preg_split('//u', $str, -1, PREG_SPLIT_NO_EMPTY);
-	$str = '';
-	foreach ($chars as $char) {
-		$o = 0;
-		$ord = ordutf8($char, $o);
-
-		if ( ($ord >= 768 && $ord <= 879) || ($ord >= 1536 && $ord <= 1791) || ($ord >= 3655 && $ord <= 3659) || ($ord >= 7616 && $ord <= 7679) || ($ord >= 8400 && $ord <= 8447) || ($ord >= 65056 && $ord <= 65071))
-			continue;
-
-		$str .= $char;
-	}
-	return $str;
+	global $config;
+	$limit = strval($config['max_combining_chars']+1);
+	return preg_replace('/(\p{Me}|\p{Mn}){'.$limit.',}/u','', $str);
 }
 
 function buildThread($id, $return = false, $mod = false) {


### PR DESCRIPTION
This merge has two parts:

1. Fix the inaccurate character stripping that removed Arabic characters

2. Allow a configurable limit of combining marks in sequence, so that they can be used appropriately in normal non-English text but cannot be abused to overlap other posts with Zalgo text.
