### PR TITLE
fix error with the newer version of twig

### DIFF
--- a/templates/mod/user.html
+++ b/templates/mod/user.html
@@ -36,7 +36,7 @@
 							{% if group_name != 'Disabled' %}
 								<li>
 									<input type="radio" name="type" id="group_{{ group_name }}" value="{{ group_value }}"> 
-									<label for="group_{{ group_name }}">{% trans group_name %}</label>
+									<label for="group_{{ group_name }}">{{ group_name|trans }}</label>
 								</li>
 							{% endif %}
 						{% endfor %}


### PR DESCRIPTION
Caught fatal error: Uncaught Twig\Error\SyntaxError: Unexpected token "name" of value "group_name" ("name" expected with value "from"). in ./vichan/templates/mod/user.html:39

done on
PHP 7.2
Apache