### PR TITLE
fix incorrect function call in body length check

### DIFF
--- a/post.php
+++ b/post.php
@@ -728,7 +728,7 @@ if (isset($_POST['delete'])) {
 			error(sprintf($config['error']['toolong'], 'email'));
 		if (mb_strlen($post['subject']) > 100)
 			error(sprintf($config['error']['toolong'], 'subject'));
-		if (!$mod && substr_count($post['body']) > $config['max_body'])
+		if (!$mod && mb_strlen($post['body']) > $config['max_body'])
 			error($config['error']['toolong_body']);
 		if (!$mod && substr_count($post['body'], "\n") >= $config['max_lines'])
 			error($config['error']['toomanylines']);


### PR DESCRIPTION
Looks like this line was mistakenly changed to call substr_count instead of mb_strlen in #572, which causes an error when you try to post (substr_count takes a minimum of two arguments).