### PR TITLE
(twig) Remove spaceless for post and file descriptions

### DIFF
--- a/templates/post_reply.html
+++ b/templates/post_reply.html
@@ -2,6 +2,7 @@
 {# tabs and new lines will be ignored #}
 <div class="post reply" id="reply_{{ post.id }}">
 <p class="intro">
+	{% endapply %}
 	{% if not index %}<a id="{{ post.id }}" class="post_anchor"></a>{% endif %}
 	<input type="checkbox" class="delete" name="delete_{{ post.id }}" id="delete_{{ post.id }}" />
 	<label for="delete_{{ post.id }}">
@@ -11,12 +12,15 @@
 		{% include 'post/flag.html' %}
 		{% include 'post/time.html' %}
 	</label>
+	{% apply spaceless %}
 	{% include 'post/poster_id.html' %}&nbsp;
 	<a class="post_no" id="post_no_{{ post.id }}" onclick="highlightReply({{ post.id }})" href="{% if isnoko50 %}{{ post.link('', '50') }}{% else %}{{ post.link }}{% endif %}">No.</a>
 	<a class="post_no" onclick="citeReply({{ post.id }})" href="{% if isnoko50 %}{{ post.link('q', '50') }}{% else %}{{ post.link('q') }}{% endif %}">{{ post.id }}</a>
 	</p>
+	{% endapply %}
     {% include 'post/fileinfo.html' %} 
     {% include 'post/post_controls.html' %}
+	{% apply spaceless %}
 	<div class="body" {% if post.files|length > 1 %}style="clear:both"{% endif %}>
 		{% endapply %}{% if index %}{{ post.body|truncate_body(post.link) }}{% else %}{{ post.body }}{% endif %}{% apply spaceless %}
 		{% if post.modifiers['ban message'] %}

--- a/templates/post_thread.html
+++ b/templates/post_thread.html
@@ -4,16 +4,19 @@
 <div class="thread" id="thread_{{ post.id }}" data-board="{{ board.uri }}">
 {% if not index %}<a id="{{ post.id }}" class="post_anchor"></a>{% endif %}
 
+{% endapply %}
 {% include 'post/fileinfo.html' %}
 <div class="post op" id="op_{{ post.id }}" {%if post.num_files > 1%}style='clear:both'{%endif%}><p class="intro">
 	<input type="checkbox" class="delete" name="delete_{{ post.id }}" id="delete_{{ post.id }}" />
 	<label for="delete_{{ post.id }}">
+		
 		{% include 'post/subject.html' %}
 		{% include 'post/name.html' %}
 		{% include 'post/ip.html' %}
 		{% include 'post/flag.html' %}
 		{% include 'post/time.html' %}
 	</label>
+	{% apply spaceless %}
 	{% include 'post/poster_id.html' %}&nbsp;
 	<a class="post_no" id="post_no_{{ post.id }}" onclick="highlightReply({{ post.id }})" href="{% if isnoko50 %}{{ post.link('', '50') }}{% else %}{{ post.link }}{% endif %}">No.</a>
 	<a class="post_no" onclick="citeReply({{ post.id }})" href="{% if isnoko50 %}{{ post.link('q', '50') }}{% else %}{{ post.link('q') }}{% endif %}">{{ post.id }}</a>


### PR DESCRIPTION
Fixes #580. Sanitization that removes this kind of stuff is elsewhere within the code, making this redundant.