### PR TITLE
Fix email logic

### DIFF
--- a/inc/api.php
+++ b/inc/api.php
@@ -80,6 +80,9 @@ class Api {
 
 			$toInt = isset(self::$ints[$translated]);
 			$val = $object->$local;
+			if (isset($this->config['hide_email']) && $this->config['hide_email'] && $local === 'email') {
+				$val = '';
+			}
 			if ($val !== null && $val !== '') {
 				$apiPost[$translated] = $toInt ? (int) $val : $val;
 			}

--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -21,15 +21,20 @@
 		</tr>{% endif %}
 		{% if not config.field_disable_email or (mod and post.mod|hasPermission(config.mod.bypass_field_disable, board.uri)) %}<tr>
 			<th>
+				{% if (mod and not post.mod|hasPermission(config.mod.bypass_field_disable, board.uri) and config.field_email_selectbox) or (not mod and config.field_email_selectbox) or (config.hide_email) %}
+					{% trans %}Options{% endtrans %}
+				{% else %}
 				{% trans %}Email{% endtrans %}
+				{% endif %}
 				{{ antibot.html() }}
 			</th>
 			<td>
-				{% if config.field_email_selectbox %}
+				{% if (mod and not post.mod|hasPermission(config.mod.bypass_field_disable, board.uri) and config.field_email_selectbox) or (not mod and config.field_email_selectbox) %}
 				<select name="email" id="email_selectbox" autocomplete="off">
 					<option value=""></option>
 					<option value="sage">sage</option>
 					{% if not config.always_noko %}<option value="noko">noko</option>{% endif %}
+					{% if config.always_noko %}<option value="nonoko">nonoko</option>{% endif %}
 				</select>
 				{% else %}
 				<input type="text" name="email" size="25" maxlength="40" autocomplete="off">


### PR DESCRIPTION
The following is changed:
If the selectbox is supposed to show, the field will display "options" instead.
If a mod is able to bypass fields, the selectbox will not show.
If hide_email is enabled, the field will always display "options" instead.
If hide_email is enabled, emails will no longer show up in the api.