### PR TITLE
Discontinuation of PHP compatibility for versions before 7.4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ improvements.
 
 Requirements
 ------------
-1.	PHP >= 5.4 (we still try to keep compatibility with php 5.3 as much as possible)
-        PHP 7.0 is explicitly supported. PHP 7.2 works as well, but may cause as yet unreported bugs.
+1.	PHP >= 7.4
 2.	MySQL/MariaDB server
 3.	[mbstring](http://www.php.net/manual/en/mbstring.installation.php) 
 4.	[PHP GD](http://www.php.net/manual/en/intro.image.php)

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,9 @@
     "description": "vichan imageboard",
     "type": "project",
     "require": {
-        "ext-mbstring": ">=5.4",
-        "ext-gd": ">=5.4",
-        "ext-pdo": ">=5.4",
+        "ext-mbstring": ">=7.4",
+        "ext-gd": ">=7.4",
+        "ext-pdo": ">=7.4",
         "twig/twig": "^2.9",
         "phpmyadmin/twig-i18n-extension": "^4.0",
         "lifo/ip": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,11 @@
     "name": "vichan-devel/vichan",
     "description": "vichan imageboard",
     "type": "project",
+    "config": {
+        "platform": {
+            "php": ">=7.4"
+        }
+    },
     "require": {
         "ext-mbstring": ">=7.4",
         "ext-gd": ">=7.4",

--- a/install.php
+++ b/install.php
@@ -729,10 +729,10 @@ if ($step == 0) {
 	$tests = array(
 		array(
 			'category' => 'PHP',
-			'name' => 'PHP &ge; 5.4',
+			'name' => 'PHP &ge; 7.4',
 			'result' => PHP_VERSION_ID >= 50400,
 			'required' => true,
-			'message' => 'vichan requires PHP 5.4 or better.',
+			'message' => 'vichan requires PHP 7.4 or better.',
 		),
 		array(
 			'category' => 'PHP',


### PR DESCRIPTION
For example, #605 contains certain changes that would break vichan on earlier versions of PHP, in order to maintain compatibility with PHP 8. This is something I've discussed a bit.

Left as an open PR for discussion.