### PR TITLE
prohibit file-selector.js from running on ios

### DIFF
--- a/js/file-selector.js
+++ b/js/file-selector.js
@@ -8,6 +8,11 @@
  */
 function init_file_selector(max_images) {
 
+	// Temporarily block iOS
+    if (/iPad|iPhone|iPod/.test(navigator.userAgent)) {
+        return;
+    }
+
 $(document).ready(function () {
 	// add options panel item
 	if (window.Options && Options.get_tab('general')) {


### PR DESCRIPTION
due to the way that ios handles file uploads, uploading from iOS completely breaks when using this script.