### PR TITLE
Fix composer.json platform

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,11 @@
     "type": "project",
     "config": {
         "platform": {
-            "php": ">=7.4"
+            "php": "7.4"
         }
     },
     "require": {
+        "php": ">=7.4",
         "ext-mbstring": ">=7.4",
         "ext-gd": ">=7.4",
         "ext-pdo": ">=7.4",


### PR DESCRIPTION
Running composer fails with a parsing error on my machine (composer 2.6.6). This patch fixes the issue while keeping the php version constrains.