### PR TITLE
Remove obsolete dbschema.sql

### DIFF
--- a/inc/captcha/dbschema.sql
+++ b/inc/captcha/dbschema.sql
@@ -1,9 +1,0 @@
-SET NAMES utf8;
-
-CREATE TABLE `captchas` (
-  `cookie` VARCHAR(50),
-  `extra` VARCHAR(200),
-  `text` VARCHAR(255),
-  `created_at` INT(11),
-  PRIMARY KEY (cookie, extra)
-) ENGINE=MyISAM  DEFAULT CHARSET=utf8mb4;

--- a/inc/captcha/readme.md
+++ b/inc/captcha/readme.md
@@ -1,10 +1,8 @@
 I integrated this from: https://github.com/ctrlcctrlv/infinity/commit/62a6dac022cb338f7b719d0c35a64ab3efc64658
 
-<strike>First import the captcha/dbschema.sql in your database</strike> it is no longer required.
-
 In inc/captcha/config.php change the database_name database_user database_password to your own settings.
 
-Add js/captcha.js in your secrets.php or config.php 
+Add js/captcha.js in your secrets.php or config.php
 
 Go to Line 305 in the /inc/config file and copy the settings in instance config, while changing the url to your website.
 Go to the line beneath it if you only want to enable it when posting a new thread.


### PR DESCRIPTION
The sql schema was merged into `install.sql` forever ago, and is already obsolete according to the README.