### PR TITLE
Remove cache backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Requirements
 ------------
 1.	PHP >= 7.4
 2.	MySQL/MariaDB server
-3.	[mbstring](http://www.php.net/manual/en/mbstring.installation.php) 
+3.	[mbstring](http://www.php.net/manual/en/mbstring.installation.php)
 4.	[PHP GD](http://www.php.net/manual/en/intro.image.php)
 5.	[PHP PDO](http://www.php.net/manual/en/intro.pdo.php)
 6.	A Unix-like OS, preferrably FreeBSD or GNU/Linux
@@ -63,7 +63,7 @@ Installation
 
         git clone git://github.com/vichan-devel/vichan.git
 
-2.	run ```composer install``` inside the directory	
+2.	run ```composer install``` inside the directory
 3.	Navigate to ```install.php``` in your web browser and follow the
 	prompts.
 4.	vichan should now be installed. Log in to ```mod.php``` with the

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ We try to make sure vichan is compatible with all major web servers. vichan does
 2.	ImageMagick (command-line ImageMagick or GraphicsMagick preferred).
 3.	~~[APC (Alternative PHP Cache)](http://php.net/manual/en/book.apc.php)~~,
 	[APCu (Alternative PHP Cache)](http://php.net/manual/en/book.apcu.php),
-	[XCache](http://xcache.lighttpd.net/),
 	[Memcached](http://www.php.net/manual/en/intro.memcached.php) or
 	[Redis](https://redis.io/docs/about/)
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ We try to make sure vichan is compatible with all major web servers. vichan does
 ### Recommended
 1.	MySQL/MariaDB server >= 5.5.3
 2.	ImageMagick (command-line ImageMagick or GraphicsMagick preferred).
-3.	~~[APC (Alternative PHP Cache)](http://php.net/manual/en/book.apc.php)~~,
-	[APCu (Alternative PHP Cache)](http://php.net/manual/en/book.apcu.php),
+3.	[APCu (Alternative PHP Cache)](http://php.net/manual/en/book.apcu.php),
 	[Memcached](http://www.php.net/manual/en/intro.memcached.php) or
 	[Redis](https://redis.io/docs/about/)
 

--- a/inc/cache.php
+++ b/inc/cache.php
@@ -41,9 +41,6 @@ class Cache {
 					self::init();
 				$data = self::$cache->get($key);
 				break;
-			case 'apc':
-				$data = apc_fetch($key);
-				break;
 			case 'apcu':
 				$data = apcu_fetch($key);
 				break;
@@ -92,9 +89,6 @@ class Cache {
 					self::init();
 				self::$cache->setex($key, $expires, json_encode($value));
 				break;
-			case 'apc':
-				apc_store($key, $value, $expires);
-				break;
 			case 'apcu':
 				apcu_store($key, $value, $expires);
 				break;
@@ -127,9 +121,6 @@ class Cache {
 					self::init();
 				self::$cache->del($key);
 				break;
-			case 'apc':
-				apc_delete($key);
-				break;
 			case 'apcu':
 				apcu_delete($key);
 				break;
@@ -154,8 +145,6 @@ class Cache {
 				if (!self::$cache)
 					self::init();
 				return self::$cache->flush();
-			case 'apc':
-				return apc_clear_cache('user');
 			case 'apcu':
 				return apcu_clear_cache('user');
 			case 'php':

--- a/inc/cache.php
+++ b/inc/cache.php
@@ -47,9 +47,6 @@ class Cache {
 			case 'apcu':
 				$data = apcu_fetch($key);
 				break;
-			case 'xcache':
-				$data = xcache_get($key);
-				break;
 			case 'php':
 				$data = isset(self::$cache[$key]) ? self::$cache[$key] : false;
 				break;
@@ -101,9 +98,6 @@ class Cache {
 			case 'apcu':
 				apcu_store($key, $value, $expires);
 				break;
-			case 'xcache':
-				xcache_set($key, $value, $expires);
-				break;
 			case 'fs':
 				$key = str_replace('/', '::', $key);
 				$key = str_replace("\0", '', $key);
@@ -138,9 +132,6 @@ class Cache {
 				break;
 			case 'apcu':
 				apcu_delete($key);
-				break;
-			case 'xcache':
-				xcache_unset($key);
 				break;
 			case 'fs':
 				$key = str_replace('/', '::', $key);

--- a/inc/cache.php
+++ b/inc/cache.php
@@ -10,7 +10,7 @@ class Cache {
 	private static $cache;
 	public static function init() {
 		global $config;
-		
+
 		switch ($config['cache']['enabled']) {
 			case 'memcached':
 				self::$cache = new Memcached();
@@ -31,9 +31,9 @@ class Cache {
 	}
 	public static function get($key) {
 		global $config, $debug;
-		
+
 		$key = $config['cache']['prefix'] . $key;
-		
+
 		$data = false;
 		switch ($config['cache']['enabled']) {
 			case 'memcached':
@@ -70,20 +70,20 @@ class Cache {
 				$data = json_decode(self::$cache->get($key), true);
 				break;
 		}
-		
+
 		if ($config['debug'])
 			$debug['cached'][] = $key . ($data === false ? ' (miss)' : ' (hit)');
-		
+
 		return $data;
 	}
 	public static function set($key, $value, $expires = false) {
 		global $config, $debug;
-		
+
 		$key = $config['cache']['prefix'] . $key;
-		
+
 		if (!$expires)
 			$expires = $config['cache']['timeout'];
-		
+
 		switch ($config['cache']['enabled']) {
 			case 'memcached':
 				if (!self::$cache)
@@ -113,15 +113,15 @@ class Cache {
 				self::$cache[$key] = $value;
 				break;
 		}
-		
+
 		if ($config['debug'])
 			$debug['cached'][] = $key . ' (set)';
 	}
 	public static function delete($key) {
 		global $config, $debug;
-		
+
 		$key = $config['cache']['prefix'] . $key;
-		
+
 		switch ($config['cache']['enabled']) {
 			case 'memcached':
 				if (!self::$cache)
@@ -151,13 +151,13 @@ class Cache {
 				unset(self::$cache[$key]);
 				break;
 		}
-		
+
 		if ($config['debug'])
 			$debug['cached'][] = $key . ' (deleted)';
 	}
 	public static function flush() {
 		global $config;
-		
+
 		switch ($config['cache']['enabled']) {
 			case 'memcached':
 				if (!self::$cache)
@@ -181,7 +181,7 @@ class Cache {
 					self::init();
 				return self::$cache->flushDB();
 		}
-		
+
 		return false;
 	}
 }

--- a/inc/config.php
+++ b/inc/config.php
@@ -121,7 +121,7 @@
 	 */
 
 	$config['cache']['enabled'] = 'php';
-	// $config['cache']['enabled'] = 'apc';
+	// $config['cache']['enabled'] = 'apcu';
 	// $config['cache']['enabled'] = 'memcached';
 	// $config['cache']['enabled'] = 'redis';
 	// $config['cache']['enabled'] = 'fs';
@@ -1306,7 +1306,6 @@
 	$config['file_mod_debug_antispam'] = 'mod/debug/antispam.html';
 	$config['file_mod_debug_recent_posts'] = 'mod/debug/recent_posts.html';
 	$config['file_mod_debug_sql'] = 'mod/debug/sql.html';
-	$config['file_mod_debug_apc'] = 'mod/debug/apc.html';
 
 	// Board directory, followed by a forward-slash (/).
 	$config['board_path'] = '%s/';
@@ -1707,8 +1706,6 @@
 	$config['mod']['news_delete'] = ADMIN;
 	// Execute un-filtered SQL queries on the database (?/debug/sql)
 	$config['mod']['debug_sql'] = DISABLED;
-	// Look through all cache values for debugging when APC is enabled (?/debug/apc)
-	$config['mod']['debug_apc'] = ADMIN;
 	// Edit the current configuration (via web interface)
 	$config['mod']['edit_config'] = ADMIN;
 	// View ban appeals

--- a/inc/config.php
+++ b/inc/config.php
@@ -121,7 +121,6 @@
 	 */
 
 	$config['cache']['enabled'] = 'php';
-	// $config['cache']['enabled'] = 'xcache';
 	// $config['cache']['enabled'] = 'apc';
 	// $config['cache']['enabled'] = 'memcached';
 	// $config['cache']['enabled'] = 'redis';

--- a/inc/config.php
+++ b/inc/config.php
@@ -2,7 +2,7 @@
 
 /*
  *  Copyright (c) 2010-2013 Tinyboard Development Group
- *  
+ *
  *  WARNING: This is a project-wide configuration file and is overwritten when upgrading to a newer
  *  version of vichan. Please leave this file unchanged, or it will be a lot harder for you to upgrade.
  *  If you would like to make instance-specific changes to your own setup, please use secrets.php.
@@ -114,7 +114,7 @@
 
 	/*
 	 * On top of the static file caching system, you can enable the additional caching system which is
-	 * designed to minimize SQL queries and can significantly increase speed when posting or using the 
+	 * designed to minimize SQL queries and can significantly increase speed when posting or using the
 	 * moderator interface. APC is the recommended method of caching.
 	 *
 	 * https://github.com/vichan-devel/vichan/wiki/cache
@@ -202,7 +202,7 @@
 	// Prevents most Tor exit nodes from making posts. Recommended, as a lot of abuse comes from Tor because
 	// of the strong anonymity associated with it.
 	// Example: $config['dnsbl'][] = 'another.blacklist.net';
-	// $config['dnsbl'][] = array('tor.dnsbl.sectoor.de', 1); //sectoor.de site is dead. the number stands for (an) ip adress(es) I guess. 
+	// $config['dnsbl'][] = array('tor.dnsbl.sectoor.de', 1); //sectoor.de site is dead. the number stands for (an) ip adress(es) I guess.
 
 	// Replacement for sectoor.de
 	$config['dnsbl'][] = array('rbl.efnetrbl.org', 4);
@@ -213,22 +213,22 @@
 	// http://www.projecthoneypot.org/httpbl.php
 	// $config['dnsbl'][] = array('<your access key>.%.dnsbl.httpbl.org', function($ip) {
 	//	$octets = explode('.', $ip);
-	//	
+	//
 	//	// days since last activity
 	//	if ($octets[1] > 14)
 	//		return false;
-	//	
+	//
 	//	// "threat score" (http://www.projecthoneypot.org/threat_info.php)
 	//	if ($octets[2] < 5)
 	//		return false;
-	//	
+	//
 	//	return true;
 	// }, 'dnsbl.httpbl.org'); // hide our access key
 
 	// Skip checking certain IP addresses against blacklists (for troubleshooting or whatever)
 	$config['dnsbl_exceptions'][] = '127.0.0.1';
 
-	// To prevent bump attacks; returns the thread to last position after the last post is deleted. 
+	// To prevent bump attacks; returns the thread to last position after the last post is deleted.
 	$config['anti_bump_flood'] = false;
 
 	/*
@@ -321,7 +321,7 @@
 	$config['hcaptcha_public'] = '7a4b21e0-dc53-46f2-a9f8-91d2e74b63a0';
 	$config['hcaptcha_private'] = '0x4e9A01bE637b51dC41a7Ea9865C3fDe4aB72Cf17';
 
-	// Enable Custom Captcha you need to change a couple of settings 
+	// Enable Custom Captcha you need to change a couple of settings
 	//Read more at: /inc/captcha/readme.md
 	$config['captcha'] = array();
 
@@ -329,7 +329,7 @@
 	$config['captcha']['enabled'] = false;
 
 	//New thread captcha
- 	//Require solving a captcha to post a thread. 
+ 	//Require solving a captcha to post a thread.
  	//Default off.
  	$config['new_thread_capt'] = false;
 
@@ -340,7 +340,7 @@
 
 	// Custom captcha extra field (eg. charset)
 	$config['captcha']['extra'] = 'abcdefghijklmnopqrstuvwxyz';
-	
+
 	// Ability to lock a board for normal users and still allow mods to post.  Could also be useful for making an archive board
 	$config['board_locked'] = false;
 
@@ -478,7 +478,7 @@
 	// 	),
 	// 	'action' => 'reject'
 	// );
-	
+
 	// Filter flood prevention conditions ("flood-match") depend on a table which contains a cache of recent
 	// posts across all boards. This table is automatically purged of older posts, determining the maximum
 	// "age" by looking at each filter. However, when determining the maximum age, vichan does not look
@@ -570,9 +570,9 @@
 	$config['markup_urls'] = true;
 
 	// Optional URL prefix for links (eg. "http://anonym.to/?").
-	$config['link_prefix'] = ''; 
+	$config['link_prefix'] = '';
 	$config['url_ads'] = &$config['link_prefix'];	 // leave alias
-	
+
 	// Allow "uploading" images via URL as well. Users can enter the URL of the image and then vichan will
 	// download it. Not usually recommended.
 	$config['allow_upload_by_url'] = false;
@@ -591,7 +591,7 @@
 	// as they are submitted and changes or censors particular words or phrases.
 
 	// For a normal string replacement:
-	// $config['wordfilters'][] = array('cat', 'dog');	
+	// $config['wordfilters'][] = array('cat', 'dog');
 	// Advanced raplcement (regular expressions):
 	// $config['wordfilters'][] = array('/ca[rt]/', 'dog', true); // 'true' means it's a regular expression
 
@@ -734,10 +734,10 @@
 	// $config['additional_javascript'][] = 'js/multi-image.js';
 	$config['max_images'] = 1;
 
-	// Method to use for determing the max filesize. 
+	// Method to use for determing the max filesize.
 	// "split" means that your max filesize is split between the images. For example, if your max filesize
-	// is 2MB, the filesizes of all files must add up to 2MB for it to work. 
-	// "each" means that each file can be 2MB, so if your max_images is 3, each post could contain 6MB of 
+	// is 2MB, the filesizes of all files must add up to 2MB for it to work.
+	// "each" means that each file can be 2MB, so if your max_images is 3, each post could contain 6MB of
 	// images. "split" is recommended.
 	$config['multiimage_method'] = 'split';
 
@@ -764,7 +764,7 @@
 	 *   'gd'		   PHP GD (default). Only handles the most basic image formats (GIF, JPEG, PNG).
 	 *				  GD is a prerequisite for vichan no matter what method you choose.
 	 *
-	 *   'imagick'	  PHP's ImageMagick bindings. Fast and efficient, supporting many image formats. 
+	 *   'imagick'	  PHP's ImageMagick bindings. Fast and efficient, supporting many image formats.
 	 *				  A few minor bugs. http://pecl.php.net/package/imagick
 	 *
 	 *   'convert'	  The command line version of ImageMagick (`convert`). Fixes most of the bugs in
@@ -790,12 +790,12 @@
 	// Use the command-line `exiftool` tool to strip EXIF metadata without decompressing/recompressing JPEGs.
 	// Ignored when $config['redraw_image'] is true.
 	$config['use_exiftool'] = false;
-	
+
 	// Redraw the image to strip any excess data (commonly ZIP archives) WARNING: This might strip the
 	// animation of GIFs, depending on the chosen thumbnailing method. It also requires recompressing
 	// the image, so more processing power is required.
 	$config['redraw_image'] = false;
-	
+
 	// Automatically correct the orientation of JPEG files using -auto-orient in `convert`. This only works
 	// when `convert` or `gm` is selected for thumbnailing. Again, requires more processing power because
 	// this basically does the same thing as $config['redraw_image']. (If $config['redraw_image'] is enabled,
@@ -880,7 +880,7 @@
 	$config['image_identification_yandex'] = true;
 	// Anime/manga search engine.
 	$config['image_identification_iqdb'] = false;
-	
+
 	// Set this to true if you're using a BSD
 	$config['bsd_md5'] = false;
 
@@ -1352,7 +1352,7 @@
 
 	// Website favicon.
 	// $config['url_favicon'] = '/favicon.gif';
-	
+
 	// Try not to build pages when we shouldn't have to.
 	$config['try_smarter'] = true;
 
@@ -1734,21 +1734,21 @@
 		'convert_args',
 		'db>password',
 	);
-	
+
 	$config['mod']['config'][JANITOR] = array(
 		'!', // Allow editing ONLY the variables listed (in this case, nothing).
 	);
-	
+
 	$config['mod']['config'][MOD] = array(
 		'!', // Allow editing ONLY the variables listed (plus that in $config['mod']['config'][JANITOR]).
 		'global_message',
 	);
-	
+
 	// Example: Disallow ADMIN from editing (and viewing) $config['db']['password'].
 	// $config['mod']['config'][ADMIN] = array(
 	// 	'db>password',
 	// );
-	
+
 	// Example: Allow ADMIN to edit anything other than $config['db']
 	// (and $config['mod']['config'][DISABLED]).
 	// $config['mod']['config'][ADMIN] = array(
@@ -1788,7 +1788,7 @@
 
 	// Limit of search results
 	$config['search']['search_limit'] = 100;
-		
+
 	// Boards for searching
 	//$config['search']['boards'] = array('a', 'b', 'c', 'd', 'e');
 
@@ -1809,7 +1809,7 @@
 
 	// event_handler('post', function($post) {
 	// 	// do something else
-	// 	
+	//
 	// 	// return an error (reject post)
 	// 	return 'Sorry, you cannot post that!';
 	// });

--- a/inc/mod/pages.php
+++ b/inc/mod/pages.php
@@ -3001,25 +3001,3 @@ function mod_debug_sql() {
 
 	mod_page(_('Debug: SQL'), $config['file_mod_debug_sql'], $args);
 }
-
-function mod_debug_apc() {
-	global $config;
-
-	if (!hasPermission($config['mod']['debug_apc']))
-		error($config['error']['noaccess']);
-
-	if ($config['cache']['enabled'] != 'apc')
-		error('APC is not enabled.');
-
-	$cache_info = apc_cache_info('user');
-
-	// $cached_vars = new APCIterator('user', '/^' . $config['cache']['prefix'] . '/');
-	$cached_vars = array();
-	foreach ($cache_info['cache_list'] as $var) {
-		if ($config['cache']['prefix'] != '' && strpos(isset($var['key']) ? $var['key'] : $var['info'], $config['cache']['prefix']) !== 0)
-			continue;
-		$cached_vars[] = $var;
-	}
-
-	mod_page(_('Debug: APC'), $config['file_mod_debug_apc'], array('cached_vars' => $cached_vars));
-}

--- a/install.php
+++ b/install.php
@@ -1,6 +1,6 @@
 <?php
 
-// Installation/upgrade file	
+// Installation/upgrade file
 define('VERSION', '5.1.4');
 require 'inc/bootstrap.php';
 loadConfig();
@@ -59,41 +59,41 @@ $page = array(
 $config['minify_html'] = false;
 
 if (file_exists($config['has_installed'])) {
-	
+
 	// Check the version number
 	$version = trim(file_get_contents($config['has_installed']));
 	if (empty($version))
 		$version = 'v0.9.1';
-	
+
 	function __query($sql) {
 		sql_open();
-		
+
 		if (mysql_version() >= 50503)
 			return query($sql);
 		else
 			return query(str_replace('utf8mb4', 'utf8', $sql));
 	}
-	
+
 	$boards = listBoards();
-	
+
 	switch ($version) {
 		case 'v0.9':
 		case 'v0.9.1':
 			// Upgrade to v0.9.2-dev
-			
+
 			foreach ($boards as &$_board) {
 				// Add `capcode` field after `trip`
 				query(sprintf("ALTER TABLE `posts_%s` ADD  `capcode` VARCHAR( 50 ) NULL AFTER  `trip`", $_board['uri'])) or error(db_error());
-				
+
 				// Resize `trip` to 15 characters
 				query(sprintf("ALTER TABLE `posts_%s` CHANGE  `trip`  `trip` VARCHAR( 15 ) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL", $_board['uri'])) or error(db_error());
 			}
 		case 'v0.9.2-dev':
 			// Upgrade to v0.9.2-dev-1
-			
+
 			// New table: `theme_settings`
 			query("CREATE TABLE IF NOT EXISTS `theme_settings` ( `name` varchar(40) NOT NULL, `value` text, UNIQUE KEY `name` (`name`)) ENGINE=InnoDB DEFAULT CHARSET=utf8;") or error(db_error());
-			
+
 			// New table: `news`
 			query("CREATE TABLE IF NOT EXISTS `news` ( `id` int(11) NOT NULL AUTO_INCREMENT, `name` text NOT NULL, `time` int(11) NOT NULL, `subject` text NOT NULL, `body` text NOT NULL, UNIQUE KEY `id` (`id`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8 AUTO_INCREMENT=1;") or error(db_error());
 		case 'v0.9.2.1-dev':
@@ -101,7 +101,7 @@ if (file_exists($config['has_installed'])) {
 			// Fix broken version number/mistake
 			$version = 'v0.9.2-dev-1';
 			// Upgrade to v0.9.2-dev-2
-			
+
 			foreach ($boards as &$_board) {
 				// Increase field sizes
 				query(sprintf("ALTER TABLE `posts_%s` CHANGE  `subject` `subject` VARCHAR( 50 ) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL", $_board['uri'])) or error(db_error());
@@ -109,7 +109,7 @@ if (file_exists($config['has_installed'])) {
 			}
 		case 'v0.9.2-dev-2':
 			// Upgrade to v0.9.2-dev-3 (v0.9.2)
-			
+
 			foreach ($boards as &$_board) {
 				// Add `custom_fields` field
 				query(sprintf("ALTER TABLE `posts_%s` ADD `embed` TEXT NULL", $_board['uri'])) or error(db_error());
@@ -117,7 +117,7 @@ if (file_exists($config['has_installed'])) {
 		case 'v0.9.2-dev-3': // v0.9.2-dev-3 == v0.9.2
 		case 'v0.9.2':
 			// Upgrade to v0.9.3-dev-1
-			
+
 			// Upgrade `theme_settings` table
 			query("TRUNCATE TABLE `theme_settings`") or error(db_error());
 			query("ALTER TABLE  `theme_settings` ADD  `theme` VARCHAR( 40 ) NOT NULL FIRST") or error(db_error());
@@ -149,7 +149,7 @@ if (file_exists($config['has_installed'])) {
 			foreach ($boards as &$board) {
 				$tables[] = "posts_{$board['uri']}";
 			}
-			
+
 			foreach ($tables as &$table) {
 				query("ALTER TABLE  `{$table}` ENGINE = INNODB DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci") or error(db_error());
 			}
@@ -173,10 +173,10 @@ if (file_exists($config['has_installed'])) {
 			query("ALTER TABLE  `boards` DROP PRIMARY KEY") or error(db_error());
 			query("ALTER TABLE  `reports` DROP INDEX  `id`") or error(db_error());
 			query("ALTER TABLE  `boards` DROP INDEX `uri`") or error(db_error());
-			
+
 			query("ALTER IGNORE TABLE  `robot` ADD PRIMARY KEY (`hash`)") or error(db_error());
 			query("ALTER TABLE  `bans` ADD FULLTEXT (`ip`)") or error(db_error());
-			query("ALTER TABLE  `ip_notes` ADD INDEX (`ip`)") or error(db_error());	
+			query("ALTER TABLE  `ip_notes` ADD INDEX (`ip`)") or error(db_error());
 			query("ALTER TABLE  `modlogs` ADD INDEX (`time`)") or error(db_error());
 			query("ALTER TABLE  `boards` ADD PRIMARY KEY(`uri`)") or error(db_error());
 			query("ALTER TABLE  `mutes` ADD INDEX (`ip`)") or error(db_error());
@@ -194,9 +194,9 @@ if (file_exists($config['has_installed'])) {
 					<p style="text-align:center">
 						<a href="?confirm=1">I have read and understood the agreement. Proceed to upgrading.</a>
 					</p>';
-				
+
 				file_write($config['has_installed'], 'v0.9.4-dev-2');
-				
+
 				break;
 			}
 		case 'v0.9.4-dev-3':
@@ -214,14 +214,14 @@ if (file_exists($config['has_installed'])) {
 			}
 			query("CREATE TABLE IF NOT EXISTS `cites` (  `board` varchar(8) NOT NULL,  `post` int(11) NOT NULL,  `target_board` varchar(8) NOT NULL,  `target` int(11) NOT NULL,  KEY `target` (`target_board`,`target`),  KEY `post` (`board`,`post`)) ENGINE=InnoDB DEFAULT CHARSET=utf8;") or error(db_error());
 		case 'v0.9.5-dev-2':
-			query("ALTER TABLE  `boards` 
+			query("ALTER TABLE  `boards`
 				CHANGE  `uri`  `uri` VARCHAR( 15 ) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL,
 				CHANGE  `title`  `title` VARCHAR( 40 ) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL,
 				CHANGE  `subtitle`  `subtitle` VARCHAR( 120 ) CHARACTER SET utf8 COLLATE utf8_general_ci NULL") or error(db_error());
 		case 'v0.9.5-dev-3':
 			// v0.9.5
 		case 'v0.9.5':
-			query("ALTER TABLE  `boards` 
+			query("ALTER TABLE  `boards`
 				CHANGE  `uri`  `uri` VARCHAR( 50 ) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL,
 				CHANGE  `title`  `title` TINYTEXT CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL,
 				CHANGE  `subtitle`  `subtitle` TINYTEXT CHARACTER SET utf8 COLLATE utf8_general_ci NULL") or error(db_error());
@@ -248,12 +248,12 @@ if (file_exists($config['has_installed'])) {
 				$query->bindValue(':newboard', $board['uri']);
 				$query->bindValue(':oldboard', $board['id']);
 				$query->execute() or error(db_error($query));
-				
+
 				$query = prepare("UPDATE `modlogs` SET `board` = :newboard WHERE `board` = :oldboard");
 				$query->bindValue(':newboard', $board['uri']);
 				$query->bindValue(':oldboard', $board['id']);
 				$query->execute() or error(db_error($query));
-				
+
 				$query = prepare("UPDATE `reports` SET `board` = :newboard WHERE `board` = :oldboard");
 				$query->bindValue(':newboard', $board['uri']);
 				$query->bindValue(':oldboard', $board['id']);
@@ -291,10 +291,10 @@ if (file_exists($config['has_installed'])) {
 				if (strlen($user['password']) == 40) {
 					mt_srand(microtime(true) * 100000 + memory_get_usage(true));
 					$salt = md5(uniqid(mt_rand(), true));
-			
+
 					$user['salt'] = $salt;
 					$user['password'] = hash('sha256', $user['salt'] . $user['password']);
-			
+
 					$_query = prepare("UPDATE `mods` SET `password` = :password, `salt` = :salt WHERE `id` = :id");
 					$_query->bindValue(':id', $user['id']);
 					$_query->bindValue(':password', $user['password']);
@@ -326,7 +326,7 @@ if (file_exists($config['has_installed'])) {
 					CHANGE `embed` `embed` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL DEFAULT NULL,
 					DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;", $board['uri'])) or error(db_error());
 			}
-			
+
 			__query("ALTER TABLE  `antispam`
 				CHANGE  `board`  `board` VARCHAR( 120 ) CHARACTER SET ASCII COLLATE ascii_general_ci NOT NULL ,
 				CHANGE  `hash`  `hash` CHAR( 40 ) CHARACTER SET ASCII COLLATE ascii_bin NOT NULL ,
@@ -486,44 +486,44 @@ if (file_exists($config['has_installed'])) {
 				) ENGINE=InnoDB  DEFAULT CHARSET=utf8mb4 AUTO_INCREMENT=1") or error(db_error());
 			$listquery = query("SELECT * FROM ``bans`` ORDER BY `id`") or error(db_error());
 			while ($ban = $listquery->fetch(PDO::FETCH_ASSOC)) {
-				$query = prepare("INSERT INTO ``bans_new_temp`` VALUES 
+				$query = prepare("INSERT INTO ``bans_new_temp`` VALUES
 					(NULL, :ipstart, :ipend, :created, :expires, :board, :creator, :reason, :seen, NULL)");
-				
+
 				$range = Bans::parse_range($ban['ip']);
 				if ($range === false) {
 					// Invalid retard ban; just skip it.
 					continue;
 				}
-				
+
 				$query->bindValue(':ipstart', $range[0]);
 				if ($range[1] !== false && $range[1] != $range[0])
 					$query->bindValue(':ipend', $range[1]);
 				else
 					$query->bindValue(':ipend', null, PDO::PARAM_NULL);
-				
+
 				$query->bindValue(':created', $ban['set']);
-				
+
 				if ($ban['expires'])
 					$query->bindValue(':expires', $ban['expires']);
 				else
 					$query->bindValue(':expires', null, PDO::PARAM_NULL);
-				
+
 				if ($ban['board'])
 					$query->bindValue(':board', $ban['board']);
 				else
 					$query->bindValue(':board', null, PDO::PARAM_NULL);
-				
+
 				$query->bindValue(':creator', $ban['mod']);
-				
+
 				if ($ban['reason'])
 					$query->bindValue(':reason', $ban['reason']);
 				else
 					$query->bindValue(':reason', null, PDO::PARAM_NULL);
-				
+
 				$query->bindValue(':seen', $ban['seen']);
 				$query->execute() or error(db_error($query));
 			}
-			
+
 			// Drop old bans table
 			query("DROP TABLE ``bans``") or error(db_error());
 			// Replace with new table
@@ -555,9 +555,9 @@ if (file_exists($config['has_installed'])) {
 					<p style="text-align:center">
 						<a href="?confirm2=1">I have read and understood the agreement. Proceed to upgrading.</a>
 					</p>';
-				
+
 				file_write($config['has_installed'], '4.4.97');
-				
+
 				break;
 			}
 		case '4.4.98-pre':
@@ -573,9 +573,9 @@ if (file_exists($config['has_installed'])) {
 					<p style="text-align:center">
 						<a href="?confirm3=1">I have read and understood the warning. Proceed to upgrading.</a>
 					</p>';
-				
+
 				file_write($config['has_installed'], '4.5.2');
-				
+
 				break;
 			}
 
@@ -641,7 +641,7 @@ if (file_exists($config['has_installed'])) {
 
 			// Update version number
 			file_write($config['has_installed'], VERSION);
-			
+
 			$page['title'] = 'Upgraded';
 			$page['body'] = '<p style="text-align:center">Successfully upgraded from ' . $version . ' to <strong>' . VERSION . '</strong>.</p>';
 			break;
@@ -653,8 +653,8 @@ if (file_exists($config['has_installed'])) {
 			$page['title'] = 'Already installed';
 			$page['body'] = '<p style="text-align:center">It appears that vichan is already installed (' . $version . ') and there is nothing to upgrade! Delete <strong>' . $config['has_installed'] . '</strong> to reinstall.</p>';
 			break;
-	}			
-	
+	}
+
 	die(Element('page.html', $page));
 }
 
@@ -686,11 +686,11 @@ if ($step == 0) {
 	<p style="text-align:center">
 		<a href="?step=1">I have read and understood the agreement. Proceed to installation.</a>
 	</p>';
-	
+
 	echo Element('page.html', $page);
 } elseif ($step == 1) {
 	$page['title'] = 'Pre-installation test';
-	
+
 	$can_exec = true;
 	if (!function_exists('shell_exec'))
 		$can_exec = false;
@@ -700,12 +700,12 @@ if ($step == 0) {
 		$can_exec = false;
 	elseif (trim(shell_exec('echo "TEST"')) !== 'TEST')
 		$can_exec = false;
-	
+
 	if (!defined('PHP_VERSION_ID')) {
 		$version = explode('.', PHP_VERSION);
 		define('PHP_VERSION_ID', ($version[0] * 10000 + $version[1] * 100 + $version[2]));
 	}
-	
+
 	// Required extensions
 	$extensions = array(
 		'PDO' => array(
@@ -893,7 +893,7 @@ if ($step == 0) {
 	);
 
 	$config['font_awesome'] = true;
-	
+
 	$additional_config = array();
 	foreach ($tests as $test) {
 		if ($test['result'] && isset($test['effect'])) {
@@ -921,7 +921,7 @@ if ($step == 0) {
 	$sg = new SaltGen();
 	$config['cookies']['salt'] = $sg->generate();
 	$config['secure_trip_salt'] = $sg->generate();
-	
+
 	echo Element('page.html', array(
 		'body' => Element('installer/config.html', array(
 			'config' => $config,
@@ -934,7 +934,7 @@ if ($step == 0) {
 	$more = $_POST['more'];
 	unset($_POST['more']);
 
-	$instance_config = 
+	$instance_config =
 '<'.'?php
 
 /*
@@ -946,13 +946,13 @@ if ($step == 0) {
 */
 
 ';
-	
+
 	create_config_from_array($instance_config, $_POST);
-	
+
 	$instance_config .= "\n";
 	$instance_config .= $more;
 	$instance_config .= "\n";
-	
+
 	if (@file_put_contents('inc/secrets.php', $instance_config)) {
 		// flushes opcache if php >= 5.5.0 or opcache is installed via PECL
 		if (function_exists('opcache_invalidate')) {
@@ -973,22 +973,22 @@ if ($step == 0) {
 	}
 } elseif ($step == 4) {
 	// SQL installation
-	
+
 	buildJavascript();
-	
+
 	$sql = @file_get_contents('install.sql') or error("Couldn't load install.sql.");
-	
+
 	sql_open();
 	$mysql_version = mysql_version();
-	
+
 	// This code is probably horrible, but what I'm trying
 	// to do is find all of the SQL queires and put them
 	// in an array.
 	preg_match_all("/(^|\n)((SET|CREATE|INSERT).+)\n\n/msU", $sql, $queries);
 	$queries = $queries[2];
-	
+
 	$queries[] = Element('posts.sql', array('board' => 'b'));
-	
+
 	$sql_errors = '';
 	foreach ($queries as $query) {
 		if ($mysql_version < 50503)
@@ -997,10 +997,10 @@ if ($step == 0) {
 		if (!query($query))
 			$sql_errors .= '<li>' . db_error() . '</li>';
 	}
-	
+
 	$page['title'] = 'Installation complete';
 	$page['body'] = '<p style="text-align:center">Thank you for using vichan. Please remember to report any bugs you discover. <a href="https://github.com/vichan-devel/vichan/wiki/Configuration-Basics">How do I edit the config files?</a></p>';
-	
+
 	if (!empty($sql_errors)) {
 		$page['body'] .= '<div class="ban"><h2>SQL errors</h2><p>SQL errors were encountered when trying to install the database. This may be the result of using a database which is already occupied with a vichan installation; if so, you can probably ignore this.</p><p>The errors encountered were:</p><ul>' . $sql_errors . '</ul><p><a href="?step=5">Ignore errors and complete installation.</a></p></div>';
 	} else {
@@ -1009,29 +1009,29 @@ if ($step == 0) {
 			setupBoard($_board);
 			buildIndex();
 		}
-		
+
 		file_write($config['has_installed'], VERSION);
 		/*if (!file_unlink(__FILE__)) {
 			$page['body'] .= '<div class="ban"><h2>Delete install.php!</h2><p>I couldn\'t remove <strong>install.php</strong>. You will have to remove it manually.</p></div>';
 		}*/
 	}
-	
+
 	echo Element('page.html', $page);
 } elseif ($step == 5) {
 	$page['title'] = 'Installation complete';
 	$page['body'] = '<p style="text-align:center">Thank you for using vichan. Please remember to report any bugs you discover.</p>';
-	
+
 	$boards = listBoards();
 	foreach ($boards as &$_board) {
 		setupBoard($_board);
 		buildIndex();
 	}
-	
+
 	file_write($config['has_installed'], VERSION);
 	if (!file_unlink(__FILE__)) {
 		$page['body'] .= '<div class="ban"><h2>Delete install.php!</h2><p>I couldn\'t remove <strong>install.php</strong>. You will have to remove it manually.</p></div>';
 	}
-	
+
 	echo Element('page.html', $page);
 }
 

--- a/install.php
+++ b/install.php
@@ -876,12 +876,11 @@ if ($step == 0) {
 		),
 		array(
 			'category' => 'Misc',
-			'name' => 'Caching available (APC(u), XCache, Memcached or Redis)',
+			'name' => 'Caching available (APC(u), Memcached or Redis)',
 			'result' => extension_loaded('apcu') || extension_loaded('apc') ||
-						extension_loaded('xcache') || extension_loaded('memcached') ||
-						extension_loaded('redis'),
+						extension_loaded('memcached') || extension_loaded('redis'),
 			'required' => false,
-			'message' => 'You will not be able to enable the additional caching system, designed to minimize SQL queries and significantly improve performance. <a href="http://php.net/manual/en/book.apc.php">APC</a> is the recommended method of caching, but <a href="http://xcache.lighttpd.net/">XCache</a>, <a href="http://www.php.net/manual/en/intro.memcached.php">Memcached</a> and <a href="http://pecl.php.net/package/redis">Redis</a> are also supported.'
+			'message' => 'You will not be able to enable the additional caching system, designed to minimize SQL queries and significantly improve performance. <a href="http://php.net/manual/en/book.apc.php">APC</a> is the recommended method of caching, but <a href="http://www.php.net/manual/en/intro.memcached.php">Memcached</a> and <a href="http://pecl.php.net/package/redis">Redis</a> are also supported.'
 		),
 		array(
 			'category' => 'Misc',

--- a/install.php
+++ b/install.php
@@ -876,11 +876,10 @@ if ($step == 0) {
 		),
 		array(
 			'category' => 'Misc',
-			'name' => 'Caching available (APC(u), Memcached or Redis)',
-			'result' => extension_loaded('apcu') || extension_loaded('apc') ||
-						extension_loaded('memcached') || extension_loaded('redis'),
+			'name' => 'Caching available (APCu, Memcached or Redis)',
+			'result' => extension_loaded('apcu') || extension_loaded('memcached') || extension_loaded('redis'),
 			'required' => false,
-			'message' => 'You will not be able to enable the additional caching system, designed to minimize SQL queries and significantly improve performance. <a href="http://php.net/manual/en/book.apc.php">APC</a> is the recommended method of caching, but <a href="http://www.php.net/manual/en/intro.memcached.php">Memcached</a> and <a href="http://pecl.php.net/package/redis">Redis</a> are also supported.'
+			'message' => 'You will not be able to enable the additional caching system, designed to minimize SQL queries and significantly improve performance. <a href="https://www.php.net/manual/en/book.apcu.php">APCu</a> is the recommended method of caching, but <a href="http://www.php.net/manual/en/intro.memcached.php">Memcached</a> and <a href="http://pecl.php.net/package/redis">Redis</a> are also supported.'
 		),
 		array(
 			'category' => 'Misc',

--- a/mod.php
+++ b/mod.php
@@ -96,7 +96,6 @@ $pages = array(
 	// these pages aren't listed in the dashboard without $config['debug']
 	//'/debug/antispam'			=> 'debug_antispam',
 	//'/debug/recent'				=> 'debug_recent_posts',
-	//'/debug/apc'				=> 'debug_apc',
 	//'/debug/sql'				=> 'secure_POST debug_sql',
 
 	// This should always be at the end:

--- a/mod.php
+++ b/mod.php
@@ -20,16 +20,16 @@ $pages = array(
 	'/'					=> 'dashboard',			// dashboard
 	'/confirm/(.+)'				=> 'confirm',			// confirm action (if javascript didn't work)
 	'/logout'				=> 'secure logout',		// logout
-	
+
 	'/users'				=> 'users',			// manage users
 	'/users/(\d+)/(promote|demote)'		=> 'secure user_promote',	// prmote/demote user
 	'/users/(\d+)'				=> 'secure_POST user',		// edit user
 	'/users/new'				=> 'secure_POST user_new',	// create a new user
-	
+
 	'/new_PM/([^/]+)'			=> 'secure_POST new_pm',	// create a new pm
 	'/PM/(\d+)(/reply)?'			=> 'pm',			// read a pm
 	'/inbox'				=> 'inbox',			// pm inbox
-	
+
 	'/log'					=> 'log',			// modlog
 	'/log/(\d+)'				=> 'log',			// modlog
 	'/log:([^/:]+)'				=> 'user_log',			// modlog
@@ -45,18 +45,18 @@ $pages = array(
 	'/edit_page/(\d+)'			=> 'secure_POST edit_page',
 	'/edit_pages/delete/([a-z0-9]+)'	=> 'secure delete_page',
 	'/edit_pages/delete/([a-z0-9]+)/(\%b)'	=> 'secure delete_page_board',
-	
+
 	'/noticeboard'				=> 'secure_POST noticeboard',	// view noticeboard
 	'/noticeboard/(\d+)'			=> 'secure_POST noticeboard',	// view noticeboard
 	'/noticeboard/delete/(\d+)'		=> 'secure noticeboard_delete',	// delete from noticeboard
-	
+
 	'/edit/(\%b)'				=> 'secure_POST edit_board',	// edit board details
 	'/new-board'				=> 'secure_POST new_board',	// create a new board
-	
+
 	'/rebuild'				=> 'secure_POST rebuild',	// rebuild static files
 	'/reports'				=> 'reports',			// report queue
 	'/reports/(\d+)/dismiss(&all|&post)?'		=> 'secure report_dismiss',	// dismiss a report
-	
+
 	'/IP/([\w.:]+)'				=> 'secure_POST ip',		// view ip address
 	'/IP/([\w.:]+)/remove_note/(\d+)'	=> 'secure ip_remove_note',	// remove note from ip address
 
@@ -65,7 +65,7 @@ $pages = array(
 	'/bans.json'				=> 'secure bans_json',		// ban list JSON
 	'/edit_ban/(\d+)'			=> 'secure_POST edit_ban',
 	'/ban-appeals'				=> 'secure_POST ban_appeals',	// view ban appeals
-	
+
 	'/recent/(\d+)'				=> 'recent_posts',		// view recent posts
 
 	'/search'				=> 'search_redirect',		// search
@@ -84,21 +84,21 @@ $pages = array(
 	'/(\%b)/(un)?sticky/(\d+)'		=> 'secure sticky',		// sticky thread
 	'/(\%b)/(un)?cycle/(\d+)'                         => 'secure cycle',          // cycle thread
 	'/(\%b)/bump(un)?lock/(\d+)'		=> 'secure bumplock',		// "bumplock" thread
-	
+
 	'/themes'				=> 'themes_list',		// manage themes
 	'/themes/(\w+)'				=> 'secure_POST theme_configure',		// configure/reconfigure theme
 	'/themes/(\w+)/rebuild'			=> 'secure theme_rebuild',		// rebuild theme
 	'/themes/(\w+)/uninstall'		=> 'secure theme_uninstall',		// uninstall theme
-	
+
 	'/config'				=> 'secure_POST config',	// config editor
 	'/config/(\%b)'				=> 'secure_POST config',	// config editor
-	
+
 	// these pages aren't listed in the dashboard without $config['debug']
 	//'/debug/antispam'			=> 'debug_antispam',
 	//'/debug/recent'				=> 'debug_recent_posts',
 	//'/debug/apc'				=> 'debug_apc',
 	//'/debug/sql'				=> 'secure_POST debug_sql',
-	
+
 	// This should always be at the end:
 	'/(\%b)/'										=> 'view_board',
 	'/(\%b)/' . preg_quote($config['file_index'], '!')					=> 'view_board',
@@ -139,7 +139,7 @@ $pages = $new_pages;
 foreach ($pages as $uri => $handler) {
 	if (preg_match($uri, $query, $matches)) {
 		$matches = array_slice($matches, 1);
-		
+
 		if (isset($matches['board'])) {
 			$board_match = $matches['board'];
 			unset($matches['board']);
@@ -148,12 +148,12 @@ foreach ($pages as $uri => $handler) {
 				$matches[$key] = $board_match[1];
 			}
 		}
-		
+
 		if (is_string($handler) && preg_match('/^secure(_POST)? /', $handler, $m)) {
 			$secure_post_only = isset($m[1]);
 			if (!$secure_post_only || $_SERVER['REQUEST_METHOD'] == 'POST') {
 				$token = isset($matches['token']) ? $matches['token'] : (isset($_POST['token']) ? $_POST['token'] : false);
-				
+
 				if ($token === false) {
 					if ($secure_post_only)
 						error($config['error']['csrf']);
@@ -162,7 +162,7 @@ foreach ($pages as $uri => $handler) {
 						exit;
 					}
 				}
-			
+
 				// CSRF-protected page; validate security token
 				$actual_query = preg_replace('!/([a-f0-9]{8})$!', '', $query);
 				if ($token != make_secure_link_token(substr($actual_query, 1))) {
@@ -171,7 +171,7 @@ foreach ($pages as $uri => $handler) {
 			}
 			$handler = preg_replace('/^secure(_POST)? /', '', $handler);
 		}
-		
+
 		if ($config['debug']) {
 			$debug['mod_page'] = array(
 				'req' => $query,
@@ -201,7 +201,7 @@ foreach ($pages as $uri => $handler) {
 		} else {
 			error("Mod page '$handler' not a string, and not callable!");
 		}
-		
+
 		exit;
 	}
 }


### PR DESCRIPTION
Trim the whitespace of some files and removes old unsupported cache backends

- `xcache` last supported release was php 5.6, and the most recent commit is from 9 years ago
- `APC` has been deprecated in favour of `APCu` since php 5.5. The `apc_*` functions are only a compatibility layer