### PR TITLE
Revert "Fix composer.json platform"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,10 @@
     "type": "project",
     "config": {
         "platform": {
-            "php": "7.4"
+            "php": ">=7.4"
         }
     },
     "require": {
-        "php": ">=7.4",
         "ext-mbstring": ">=7.4",
         "ext-gd": ">=7.4",
         "ext-pdo": ">=7.4",


### PR DESCRIPTION
Reverts vichan-devel/vichan#666
reverted because it causes issues with polyfill.php


Fatal error: Uncaught Error: Failed opening required '/var/www/vichan/vendor/composer/../../inc/polyfill.php' (include_path='.:/usr/share/php') in /var/www/vichan/vendor/composer/autoload_real.php:41 Stack trace: #0 /var/www/vichan/vendor/composer/autoload_real.php(45): {closure}() #1 /var/www/vichan/vendor/autoload.php(25): ComposerAutoloaderInit87ce239fd1d5fffb74966eb3d19ab3a9::getLoader() #2 /var/www/vichan/inc/bootstrap.php(3): require_once('...') #3 /var/www/vichan/mod.php(7): require_once('...') #4 {main} thrown in /var/www/vichan/vendor/composer/autoload_real.php on line 41