### PR TITLE
Update template datetime

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -976,7 +976,7 @@
 
 	// Timezone to use for displaying dates/times.
 	$config['timezone'] = 'America/Los_Angeles';
-	// The format string passed to date_format() for displaying dates. ISO 8601-like by default.
+	// The format string passed to DateTime::format() for displaying dates. ISO 8601-like by default.
 	// https://www.php.net/manual/en/datetime.format.php
 	$config['post_date'] = 'd-m-Y (D) H:i:s';
 	// Same as above, but used for "you are banned' pages.

--- a/inc/config.php
+++ b/inc/config.php
@@ -976,11 +976,11 @@
 
 	// Timezone to use for displaying dates/times.
 	$config['timezone'] = 'America/Los_Angeles';
-	// The format string passed to strftime() for displaying dates.
-	// http://www.php.net/manual/en/function.strftime.php
-	$config['post_date'] = '%m/%d/%y (%a) %H:%M:%S';
+	// The format string passed to date_format() for displaying dates. ISO 8601-like by default.
+	// https://www.php.net/manual/en/datetime.format.php
+	$config['post_date'] = 'd-m-Y (D) H:i:s';
 	// Same as above, but used for "you are banned' pages.
-	$config['ban_date'] = '%A %e %B, %Y';
+	$config['ban_date'] = 'l j F, Y';
 
 	// The names on the post buttons. (On most imageboards, these are both just "Post").
 	$config['button_newtopic'] = _('New Topic');

--- a/inc/template.php
+++ b/inc/template.php
@@ -58,7 +58,7 @@ function Element($templateFile, array $options) {
 	}
 	
 	// Read the template file
-	if (@file_get_contents("{$config['dir']['template']}/${templateFile}")) {
+	if (@file_get_contents("{$config['dir']['template']}/{$templateFile}")) {
 		$body = $twig->render($templateFile, $options);
 		
 		if ($config['minify_html'] && preg_match('/\.html$/', $templateFile)) {
@@ -67,7 +67,7 @@ function Element($templateFile, array $options) {
 		
 		return $body;
 	} else {
-		throw new Exception("Template file '${templateFile}' does not exist or is empty in '{$config['dir']['template']}'!");
+		throw new Exception("Template file '{$templateFile}' does not exist or is empty in '{$config['dir']['template']}'!");
 	}
 }
 

--- a/inc/template.php
+++ b/inc/template.php
@@ -113,7 +113,6 @@ class Tinyboard extends Twig\Extension\AbstractExtension
 		return array(
 			new Twig\TwigFunction('time', 'time'),
 			new Twig\TwigFunction('floor', 'floor'),
-			new Twig\TwigFunction('timezone', 'twig_timezone_function'),
 			new Twig\TwigFunction('hiddenInputs', 'hiddenInputs'),
 			new Twig\TwigFunction('hiddenInputsHash', 'hiddenInputsHash'),
 			new Twig\TwigFunction('ratio', 'twig_ratio_function'),
@@ -134,17 +133,14 @@ class Tinyboard extends Twig\Extension\AbstractExtension
 	}
 }
 
-function twig_timezone_function() {
-	return 'Z';
-}
-
 function twig_push_filter($array, $value) {
 	array_push($array, $value);
 	return $array;
 }
 
 function twig_date_filter($date, $format) {
-	return gmstrftime($format, $date);
+	$date = new DateTime($date, new DateTimeZone('UTC'));
+	return $date->format($format);
 }
 
 function twig_hasPermission_filter($mod, $permission, $board = null) {

--- a/templates/post/time.html
+++ b/templates/post/time.html
@@ -1,1 +1,1 @@
- <time datetime="{{ post.time|date('%Y-%m-%dT%H:%M:%S') }}{{ timezone() }}">{{ post.time|date(config.post_date) }}</time>
+ <time datetime="{{ post.time|date('Y-m-d\\TH:i:s\Z') }}">{{ post.time|date(config.post_date) }}</time>

--- a/templates/themes/basic/index.html
+++ b/templates/themes/basic/index.html
@@ -17,7 +17,7 @@
 		<h1>{{ settings.title }}</h1>
 		<div class="subtitle">{{ settings.subtitle }}</div>
 	</header>
-	
+
 	<div class="ban">
 		{% if news|length == 0 %}
 			<p style="text-align:center" class="unimportant">(No news to show.)</p>
@@ -35,7 +35,7 @@
 			{% endfor %}
 		{% endif %}
 	</div>
-	
+
 	<hr/>
 		{% include 'footer.html' %}
 </body>

--- a/templates/themes/basic/index.html
+++ b/templates/themes/basic/index.html
@@ -29,7 +29,7 @@
 					{% else %}
 						<em>no subject</em>
 					{% endif %}
-					<span class="unimportant"> &mdash; by {{ entry.name }} at {{ entry.time|date(config.post_date, config.timezone) }}</span>
+					<span class="unimportant"> &mdash; by {{ entry.name }} at {{ entry.time|date(config.post_date) }}</span>
 				</h2>
 				<p>{{ entry.body }}</p>
 			{% endfor %}

--- a/templates/themes/catalog/catalog.html
+++ b/templates/themes/catalog/catalog.html
@@ -51,7 +51,7 @@
 						{% else %}
 							<img src="{{post.file}}"
 						{% endif %}
-						 id="img-{{ post.id }}" data-subject="{% if post.subject %}{{ post.subject|e }}{% endif %}" data-name="{{ post.name|e }}" data-muhdifference="{{ post.muhdifference }}" class="{{post.board}} thread-image" title="{{post.bump|date('%b %d %H:%M')}}">
+						 id="img-{{ post.id }}" data-subject="{% if post.subject %}{{ post.subject|e }}{% endif %}" data-name="{{ post.name|e }}" data-muhdifference="{{ post.muhdifference }}" class="{{post.board}} thread-image" title="{{post.bump|date('M d H:i')}}">
 					</a>
 						<div class="replies">
 							<strong>R: {{ post.reply_count }} / I: {{ post.image_count }}{% if post.sticky %} (sticky){% endif %}</strong>

--- a/templates/themes/catalog/catalog.html
+++ b/templates/themes/catalog/catalog.html
@@ -19,24 +19,24 @@
 		</div>
 	</header>
 
-        <span>{% trans 'Sort by' %}: </span>
-        <select id="sort_by" style="display: inline-block">
-                <option selected value="bump:desc">{% trans 'Bump order' %}</option>
-                <option value="time:desc">{% trans 'Creation date' %}</option>
-                <option value="reply:desc">{% trans 'Reply count' %}</option>
-                <option value="random:desc">{% trans 'Random' %}</option>
-        </select>
- 
-        <span>{% trans 'Image size' %}: </span>
-        <select id="image_size" style="display: inline-block">
-                <option value="vsmall">{% trans 'Very small' %}</option>
-                <option selected value="small">{% trans 'Small' %}</option>
-                <option value="large">{% trans 'Large' %}</option>
-        </select>
-        <div class="threads">
-                <div id="Grid">
-                {% for post in recent_posts %}
-                        <div class="mix"
+	<span>{% trans 'Sort by' %}: </span>
+	<select id="sort_by" style="display: inline-block">
+		<option selected value="bump:desc">{% trans 'Bump order' %}</option>
+		<option value="time:desc">{% trans 'Creation date' %}</option>
+		<option value="reply:desc">{% trans 'Reply count' %}</option>
+		<option value="random:desc">{% trans 'Random' %}</option>
+	</select>
+
+	<span>{% trans 'Image size' %}: </span>
+	<select id="image_size" style="display: inline-block">
+		<option value="vsmall">{% trans 'Very small' %}</option>
+		<option selected value="small">{% trans 'Small' %}</option>
+		<option value="large">{% trans 'Large' %}</option>
+	</select>
+	<div class="threads">
+		<div id="Grid">
+		{% for post in recent_posts %}
+			<div class="mix"
 				data-reply="{{ post.reply_count }}"
 				 data-bump="{{ post.bump }}"
 				 data-time="{{ post.time }}"
@@ -44,18 +44,18 @@
 				 data-sticky="{% if post.sticky %}true{% else %}false{% endif %}"
 				 data-locked="{% if post.locked %}true{% else %}false{% endif %}"
 			>
-                                <div class="thread grid-li grid-size-small">  
-                                        <a href="{{post.link}}">  
+				<div class="thread grid-li grid-size-small">
+					<a href="{{post.link}}">
 						{% if post.youtube %}
-							<img src="//img.youtube.com/vi/{{ post.youtube }}/0.jpg" 
+							<img src="//img.youtube.com/vi/{{ post.youtube }}/0.jpg"
 						{% else %}
-							<img src="{{post.file}}" 
+							<img src="{{post.file}}"
 						{% endif %}
-                                                 id="img-{{ post.id }}" data-subject="{% if post.subject %}{{ post.subject|e }}{% endif %}" data-name="{{ post.name|e }}" data-muhdifference="{{ post.muhdifference }}" class="{{post.board}} thread-image" title="{{post.bump|date('%b %d %H:%M')}}">
-                                        </a>
-                                                <div class="replies">
-                                                        <strong>R: {{ post.reply_count }} / I: {{ post.image_count }}{% if post.sticky %} (sticky){% endif %}</strong>
-                                                        {% if post.subject %}
+						 id="img-{{ post.id }}" data-subject="{% if post.subject %}{{ post.subject|e }}{% endif %}" data-name="{{ post.name|e }}" data-muhdifference="{{ post.muhdifference }}" class="{{post.board}} thread-image" title="{{post.bump|date('%b %d %H:%M')}}">
+					</a>
+						<div class="replies">
+							<strong>R: {{ post.reply_count }} / I: {{ post.image_count }}{% if post.sticky %} (sticky){% endif %}</strong>
+							{% if post.subject %}
 								<p class="intro">
 									<span class="subject">
 										{{ post.subject|e }}
@@ -66,13 +66,13 @@
 							{% endif %}
 
 								{{ post.body }}
-                                                </div>
-                                </div>
-                        </div>
-                {% endfor %}
-                </div>
-        </div>
-	
+						</div>
+				</div>
+			</div>
+		{% endfor %}
+		</div>
+	</div>
+
 	<hr/>
 	{% include 'footer.html' %}
 	<script type="text/javascript">{% verbatim %}

--- a/templates/themes/sitemap/sitemap.xml
+++ b/templates/themes/sitemap/sitemap.xml
@@ -10,7 +10,7 @@
 		{% for thread in thread_list %}
 			<url>
 				<loc>{{ settings.url ~ (config.board_path | format(board)) ~ config.dir.res ~ link_for(thread) }}</loc>
-				<lastmod>{{ thread.lastmod | date('%Y-%m-%dT%H:%M:%S') }}{{ timezone() }}</lastmod>
+				<lastmod>{{ thread.lastmod | date('Y-m-d\\TH:i:s\Z') }}</lastmod>
 				<changefreq>{{ settings.changefreq }}</changefreq>
 			</url>
 		{% endfor %}


### PR DESCRIPTION
Transitions away from the deprecated `gmstrftime()` function, removes the useless `timezone()` twig filter and fixes the deprecated string interning syntax in `inc/template.php`