### PR TITLE
Move twig template cache

### DIFF
--- a/inc/cache.php
+++ b/inc/cache.php
@@ -165,31 +165,3 @@ class Cache {
 		return false;
 	}
 }
-
-class Twig_Cache_TinyboardFilesystem extends Twig\Cache\FilesystemCache
-{
-	private $directory;
-	private $options;
-
-	/**
-	 * {@inheritdoc}
-	 */
-	public function __construct($directory, $options = 0)
-	{
-		parent::__construct($directory, $options);
-
-		$this->directory = $directory;
-	}
-
-	/**
-	 * This function was removed in Twig 2.x due to developer views on the Twig library. Who says we can't keep it for ourselves though?
-	 */
-	public function clear()
-	{
-		foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->directory), RecursiveIteratorIterator::LEAVES_ONLY) as $file) {
-			if ($file->isFile()) {
-				@unlink($file->getPathname());
-			}
-		}
-	}
-}

--- a/inc/template.php
+++ b/inc/template.php
@@ -18,7 +18,7 @@ function load_twig() {
 	$twig = new Twig\Environment($loader, array(
 		'autoescape' => false,
 		'cache' => is_writable('templates/') || (is_dir($cache_dir) && is_writable($cache_dir)) ?
-			new Twig_Cache_TinyboardFilesystem($cache_dir) : false,
+			new TinyboardTwigCache($cache_dir) : false,
 		'debug' => $config['debug'],
 		'auto_reload' => $config['twig_auto_reload']
 	));
@@ -70,6 +70,32 @@ function Element($templateFile, array $options) {
 		return $body;
 	} else {
 		throw new Exception("Template file '${templateFile}' does not exist or is empty in '{$config['dir']['template']}'!");
+	}
+}
+
+class TinyboardTwigCache extends Twig\Cache\FilesystemCache {
+	private string $directory;
+
+	public function __construct(string $directory) {
+		parent::__construct($directory);
+		$this->directory = $directory;
+	}
+
+	/**
+	 * This function was removed in Twig 2.x due to developer views on the Twig library.
+	 * Who says we can't keep it for ourselves though?
+	 */
+	public function clear() {
+		$iter = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator($this->directory),
+			RecursiveIteratorIterator::LEAVES_ONLY
+		);
+
+		foreach ($iter as $file) {
+			if ($file->isFile()) {
+				@unlink($file->getPathname());
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Moves the twig caching implementation in `template.php` instead of the more general cache file