### PR TITLE
config.php: reenable syslog default

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -66,7 +66,7 @@
 	$config['has_installed'] = '.installed';
 
 	// Deprecated, use 'log_system'.
-	// $config['syslog'] = false;
+	$config['syslog'] = false;
 
 	$config['log_system'] = [];
 	// Log all error messages and unauthorized login attempts.


### PR DESCRIPTION
Re-enables the old `syslog` config default. It still has references around and removing it causes warnings