### PR TITLE
fix bug with datetime

### DIFF
--- a/inc/template.php
+++ b/inc/template.php
@@ -167,8 +167,12 @@ function twig_push_filter($array, $value) {
 }
 
 function twig_date_filter($date, $format) {
-	$date = new DateTime($date, new DateTimeZone('UTC'));
-	return $date->format($format);
+    if (is_numeric($date)) {
+        $date = new DateTime("@$date", new DateTimeZone('UTC'));
+    } else {
+        $date = new DateTime($date, new DateTimeZone('UTC'));
+    }
+    return $date->format($format);
 }
 
 function twig_hasPermission_filter($mod, $permission, $board = null) {


### PR DESCRIPTION
Going to do all the PRs for bugfixes as I see them.

Fixes this error which is seen when opening the userlist:

Caught fatal error: Uncaught Exception: Failed to parse time string (1715924616) at position 8 (1): Unexpected character in /var/www/vichan520/inc/template.php:170Stack trace:#0 /var/www/vichan520/inc/template.php(170): DateTime->__construct()#1 /var/www/vichan520/templates/cache/78/78d801abd4d128ae963617940e0dba19.php(307): twig_date_filter()#2 /var/www/vichan520/vendor/twig/twig/src/Template.php(405): __TwigTemplate_5607d8c3a709524a950517dbef75f4a9->doDisplay()#3 /var/www/vichan520/vendor/twig/twig/src/Template.php(378): Twig\Template->displayWithErrorHandling()#4 /var/www/vichan520/vendor/twig/twig/src/Template.php(390): Twig\Template->display()#5 /var/www/vichan520/vendor/twig/twig/src/TemplateWrapper.php(45): Twig\Template->render()#6 /var/www/vichan520/vendor/twig/twig/src/Environment.php(318): Twig\TemplateWrapper->render()#7 /var/www/vichan520/inc/template.php(64): Twig\Environment->render()#8 /var/www/vichan520/inc/mod/pages.php(26): Element()#9 /var/www/vichan520/inc/mod/pages.php(1966): mod_page()#10 /var/www/vichan520/mod.php(194): mod_user()#11 {main}Next Twig\Error\RuntimeError: An exception has been thrown during the rendering of a template ("Failed to parse time string (1715924616) at position 8 (1): Unexpected character"). in /var/www/vichan520/templates/mod/user.html:106Stack trace:#0 /var/www/vichan520/vendor/twig/twig/src/Template.php(378): Twig\Template->displayWithErrorHandling()#1 /var/www/vichan520/vendor/twig/twig/src/Template.php(390): Twig\Template->display()#2 /var/www/vichan520/vendor/twig/twig/src/TemplateWrapper.php(45): Twig\Template->render()#3 /var/www/vichan520/vendor/twig/twig/src/Environment.php(318): Twig\TemplateWrapper->render()#4 /var/www/vichan520/inc/template.php(64): Twig\Environment->render()#5 /var/www/vichan520/inc/mod/pages.php(26): Element()#6 /var/www/vichan520/inc/mod/pages.php(1966): mod_page()#7 /var/www/vichan520/mod.php(194): mod_user()#8 {main} thrown in /var/www/vichan520/templates/mod/user.html on line 106