### PR TITLE
Use hardlinks instead of copying the file

### DIFF
--- a/inc/mod/pages.php
+++ b/inc/mod/pages.php
@@ -1342,8 +1342,8 @@ function mod_move($originBoard, $postID) {
 		if ($targetBoard === $originBoard)
 			error(_('Target and source board are the same.'));
 
-		// copy() if leaving a shadow thread behind; else, rename().
-		$clone = $shadow ? 'copy' : 'rename';
+		// link() if leaving a shadow thread behind; else, rename().
+		$clone = $shadow ? 'link' : 'rename';
 
 		// indicate that the post is a thread
 		$post['op'] = true;


### PR DESCRIPTION
Just use hardlinks instead of performing a full file copy.
This should provide a decent speedup since vichan will no longer require a full copy of the file (with the relative IO). Should be as fast as rename.