### PR TITLE
Add a spam filter that unshortens urls

### DIFF
--- a/inc/filters.php
+++ b/inc/filters.php
@@ -136,6 +136,18 @@ class Filter {
 				return $post['board'] == $match;
 			case 'password':
 				return $post['password'] == $match;
+			case 'unshorten':
+				$extracted_urls = get_urls($post['body_nomarkup']);
+				foreach ($extracted_urls as $url) {
+						$myfile = fopen("/var/www/uboachan.net/newfile.txt", "r+");
+						fwrite($myfile, $url);
+						fclose($myfile);
+
+					if (preg_match($match, trace_url($url))) {
+						return true;
+					}
+				}
+				return false;
 			default:
 				error('Unknown filter condition: ' . $condition);
 		}

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -3089,3 +3089,29 @@ function check_thread_limit($post) {
 		return $r['count'] >= $config['max_threads_per_hour'];
 	}
 }
+
+// Thanks to https://gist.github.com/marijn/3901938
+function trace_url($url) {
+	$ch = curl_init($url);
+	curl_setopt_array($ch, array(
+		CURLOPT_FOLLOWLOCATION => TRUE,  // the magic sauce
+		CURLOPT_RETURNTRANSFER => TRUE,
+		CURLOPT_SSL_VERIFYHOST => FALSE, // suppress certain SSL errors
+		CURLOPT_SSL_VERIFYPEER => FALSE,
+		CURLOPT_TIMEOUT => 30,
+	));
+	curl_exec($ch);
+	$url = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
+	curl_close($ch);
+	return $url;
+}
+
+// Thanks to https://stackoverflow.com/questions/10002227/linkify-regex-function-php-daring-fireball-method/10002262#10002262
+function get_urls($body) {
+	$regex = '(?xi)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))';
+
+	$result = preg_match_all("#$regex#i", $body, $match);
+
+	return $match[0];
+}
+


### PR DESCRIPTION
In order to combat the CP spam problem affecting a lot of imageboards right now, I added an additional spam filter which uses CURL to unshorten URLs and match against the endpoint instead of the shortened URL. I decided to do this after my moderation team observed that while the spammers have an infinite supply of URL shorteners, most shortened URLs go to just a few endpoints.

It adds two functions to inc/functions.php:

- get_urls(): Extract the URLs from a post body using REGEX, and return an array.
- trace_url(): Use CURL to follow a shortened URL and return its endpoint.

It also adds the "unshorten" filter to inc/filters.php, which works similarly to the "body" filter. Just enter a partial or whole URL to match against.

I hope that this will help to turn the tide in the CP spam issue which presently threatens the future of imageboard culture. My moderators are exhausted.