### PR TITLE
Add a spam filter that unshortens urls

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -487,6 +487,17 @@
 	// 	'action' => 'reject'
 	// );
 
+	// Example: Expand shortened links in a post, looking for and blocking URLs that lead to an unwanted
+        // endpoint. Many botspam posts include a variety of shortened URLs which all point to the same few
+        // webhosts. You can use this filter to block the endpoint webhost instead of just the apparent URL.
+	// $config['filters'][] = array(
+	// 	'condition' => array(
+	// 		'unshorten' => '/endpoint.net/i',
+	// 	),
+	// 	'action' => 'reject',
+	// 	'message' => 'None of that, please.'
+	// );
+
 	// Filter flood prevention conditions ("flood-match") depend on a table which contains a cache of recent
 	// posts across all boards. This table is automatically purged of older posts, determining the maximum
 	// "age" by looking at each filter. However, when determining the maximum age, vichan does not look

--- a/inc/filters.php
+++ b/inc/filters.php
@@ -136,6 +136,14 @@ class Filter {
 				return $post['board'] == $match;
 			case 'password':
 				return $post['password'] == $match;
+			case 'unshorten':
+				$extracted_urls = get_urls($post['body_nomarkup']);
+				foreach ($extracted_urls as $url) {
+					if (preg_match($match, trace_url($url))) {
+						return true;
+					}
+				}
+				return false;
 			default:
 				error('Unknown filter condition: ' . $condition);
 		}

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -3089,3 +3089,29 @@ function check_thread_limit($post) {
 		return $r['count'] >= $config['max_threads_per_hour'];
 	}
 }
+
+// Thanks to https://gist.github.com/marijn/3901938
+function trace_url($url) {
+	$ch = curl_init($url);
+	curl_setopt_array($ch, array(
+		CURLOPT_FOLLOWLOCATION => TRUE,  // the magic sauce
+		CURLOPT_RETURNTRANSFER => TRUE,
+		CURLOPT_SSL_VERIFYHOST => FALSE, // suppress certain SSL errors
+		CURLOPT_SSL_VERIFYPEER => FALSE,
+		CURLOPT_TIMEOUT => 30,
+	));
+	curl_exec($ch);
+	$url = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
+	curl_close($ch);
+	return $url;
+}
+
+// Thanks to https://stackoverflow.com/questions/10002227/linkify-regex-function-php-daring-fireball-method/10002262#10002262
+function get_urls($body) {
+	$regex = '(?xi)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))';
+
+	$result = preg_match_all("#$regex#i", $body, $match);
+
+	return $match[0];
+}
+


### PR DESCRIPTION
In order to combat the CP spam problem affecting a lot of imageboards right now, I added an additional spam filter which uses CURL to unshorten URLs and match against the endpoint instead of the shortened URL. I decided to do this after my moderation team observed that while the spammers have an infinite supply of URL shorteners, most shortened URLs go to just a few endpoints.

It adds two functions to inc/functions.php:

- get_urls(): Extract the URLs from a post body using REGEX, and return an array.
- trace_url(): Use CURL to follow a shortened URL and return its endpoint.

Crucially, it adds the "unshorten" filter to inc/filters.php, which works similarly to the "body" filter. Just enter a partial or whole endpoint URL to match against.

I hope that this will help to turn the tide in the CP spam debacle which presently threatens the future of imageboard culture. My janitors are exhausted, some users don't want to visit my boards anymore because of the regularity of the spam, and admins elsewhere have abandoned their sites in frustration.