### PR TITLE
Fix typo in post.php that breaks Tesseract OCR

### DIFF
--- a/post.php
+++ b/post.php
@@ -1197,7 +1197,7 @@ if (isset($_POST['delete'])) {
 					if ($txt !== '') {
 						// This one has an effect, that the body is appended to a post body. So you can write a correct
 						// spamfilter.
-						$post['body_nomarkup'] .= "<tinyboard ocr image $key>" . htmlspecialchars($value) . "</tinyboard>";
+						$post['body_nomarkup'] .= "<tinyboard ocr image $key>" . htmlspecialchars($txt) . "</tinyboard>";
 					}
 				} catch (RuntimeException $e) {
 					$context->get(Log::class)->log(Log::ERROR, "Could not OCR image: {$e->getMessage()}");


### PR DESCRIPTION
Fixes a typo in post.php that causes an uninitialized variable "$value" to be referenced instead of the correct variable "$txt". This caused all attempts to use the Tesseract OCR feature to fail with an error.