### PR TITLE
ban_form.html: add autofocus

### DIFF
--- a/templates/mod/ban_form.html
+++ b/templates/mod/ban_form.html
@@ -45,7 +45,7 @@ $(document).ready(function(){
 				<label for="reason">{% trans 'Reason' %}</label>
 			</th>
 			<td>
-				<textarea name="reason" id="reason" rows="5" cols="30">{{ reason|e }}</textarea>
+				<textarea name="reason" id="reason" rows="5" cols="30" autofocus>{{ reason|e }}</textarea>
 			</td>
 		</tr>
 		{% if post and board and not delete %}


### PR DESCRIPTION
Automatically focuses on the ban form text when it comes up. Useful to help cleanup spam