### PR TITLE
bans.php: remove multiple return types for PHP 7.4 support

### DIFF
--- a/inc/bans.php
+++ b/inc/bans.php
@@ -268,7 +268,7 @@ class Bans {
 		return [$ipstart, $ipend];
 	}
 
-	static public function findSingle(string $ip, int $ban_id, bool $require_ban_view, bool $auto_gc): array|null {
+	static public function findSingle(string $ip, int $ban_id, bool $require_ban_view, bool $auto_gc): ?array {
 		if ($auto_gc) {
 			return self::findSingleAutoGc($ip, $ban_id, $require_ban_view);
 		} else {


### PR DESCRIPTION
Ports b5a9dc4d1a1ce3173745e2e8e14ce37a25f689a3 to `dev`