### PR TITLE
skip captcha or log settings in mod.php config

### DIFF
--- a/inc/mod/config-editor.php
+++ b/inc/mod/config-editor.php
@@ -64,6 +64,10 @@ function config_vars() {
 			$var['comment'][] = $temp_comment;
 			$temp_comment = false;
 		}
+
+		if (preg_match('!^\s*\$config\[(\'log_system\'|\'captcha\')\]!', $line)) {
+            continue;
+        }
 		
 		if (preg_match('!^\s*// ([^$].*)$!', $line, $matches)) {
 			if ($var['default'] !== false) {


### PR DESCRIPTION
relates to multidimensional arrays

a quick and dirty fix since the entire current mod.php config should be cut out in 5.3.0 or 6.0.0