### PR TITLE
Docker logging

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -23,6 +23,7 @@ services:
     volumes:
       - ./local-instances/${INSTANCE:-0}/www:/var/www
       - ./docker/php/www.conf:/usr/local/etc/php-fpm.d/www.conf
+      - ./docker/php/logging.ini:/usr/local/etc/php/conf.d/logging.ini
       - ./docker/php/jit.ini:/usr/local/etc/php/conf.d/jit.ini
       - redis-sock:/var/run/redis
 

--- a/docker/php/logging.ini
+++ b/docker/php/logging.ini
@@ -1,0 +1,4 @@
+; log PHP errors to a file. E_ALL=32767
+log_errors = on
+error_reporting = 32767
+error_log = /proc/1/fd/1


### PR DESCRIPTION
Print PHP errors on the docker log. Must be enabled since they're turned off by default.