### PR TITLE
ban_history.html: fix IP display

### DIFF
--- a/templates/mod/ban_history.html
+++ b/templates/mod/ban_history.html
@@ -11,7 +11,7 @@
 	</tr>
 	<tr>
 		<th>{% trans 'IP' %}</th>
-		<td>{{ ban.cmask }}</td>
+		<td>{{ ban.mask|cloak_ip }}</td>
 	</tr>
 	<tr>
 		<th>{% trans 'Reason' %}</th>


### PR DESCRIPTION
The IP doesn't display because `ban.cmask` does not exist. This patch fixes the intend functionality.