### PR TITLE
Bump php to 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,18 +2,12 @@
     "name": "vichan-devel/vichan",
     "description": "vichan imageboard",
     "type": "project",
-    "config": {
-        "platform": {
-            "php": "7.4"
-        }
-    },
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.1",
         "ext-mbstring": ">=7.4",
         "ext-gd": ">=7.4",
         "ext-pdo": ">=7.4",
-        "twig/twig": "^2.9",
-        "phpmyadmin/twig-i18n-extension": "^4.0",
+        "twig/twig": "^3.17",
         "lifo/ip": "^1.0",
         "gettext/gettext": "^5.5",
         "mrclay/minify": "^2.1.6",

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,12 @@
     "name": "vichan-devel/vichan",
     "description": "vichan imageboard",
     "type": "project",
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/alex300/securimage.git"
+        }
+    ],
     "require": {
         "php": ">=8.1",
         "ext-mbstring": ">=7.4",
@@ -11,7 +17,7 @@
         "lifo/ip": "^1.0",
         "gettext/gettext": "^5.5",
         "mrclay/minify": "^2.1.6",
-        "dapphp/securimage": "^4.0",
+        "dapphp/securimage": "dev-nextgen",
         "erusev/parsedown":  "^1.7.4",
         "geoip2/geoip2": "^2.13"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95168426d3589b3f5bfd79a5f97b5343",
+    "content-hash": "f2d012a971c444e04acac6243fbf72e6",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -84,16 +84,16 @@
         },
         {
             "name": "dapphp/securimage",
-            "version": "4.0.2",
+            "version": "dev-nextgen",
             "source": {
                 "type": "git",
-                "url": "https://github.com/dapphp/securimage.git",
-                "reference": "aabde76d839d75a238970661187f83312c2eeda7"
+                "url": "https://github.com/Alex300/securimage.git",
+                "reference": "7fe09987b9f86866e5e37642f8e6e00299fe7063"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dapphp/securimage/zipball/aabde76d839d75a238970661187f83312c2eeda7",
-                "reference": "aabde76d839d75a238970661187f83312c2eeda7",
+                "url": "https://api.github.com/repos/Alex300/securimage/zipball/7fe09987b9f86866e5e37642f8e6e00299fe7063",
+                "reference": "7fe09987b9f86866e5e37642f8e6e00299fe7063",
                 "shasum": ""
             },
             "require": {
@@ -107,14 +107,13 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Securimage\\": "./"
-                },
                 "classmap": [
                     "securimage.php"
-                ]
+                ],
+                "psr-4": {
+                    "Securimage\\": "./"
+                }
             },
-            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
@@ -127,17 +126,15 @@
             "description": "PHP CAPTCHA Library",
             "homepage": "https://www.phpcaptcha.org",
             "keywords": [
-                "Forms",
                 "anti-spam",
                 "captcha",
+                "forms",
                 "security"
             ],
             "support": {
-                "issues": "https://github.com/dapphp/securimage/issues",
-                "source": "https://github.com/dapphp/securimage/tree/4.0.2"
+                "source": "https://github.com/Alex300/securimage/tree/nextgen"
             },
-            "abandoned": true,
-            "time": "2020-05-30T10:05:48+00:00"
+            "time": "2024-09-30T08:46:02+00:00"
         },
         {
             "name": "erusev/parsedown",
@@ -918,7 +915,9 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "dapphp/securimage": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5fc42e63c61b5d69693a300f026d7d58",
+    "content-hash": "95168426d3589b3f5bfd79a5f97b5343",
     "packages": [
         {
             "name": "composer/ca-bundle",
-            "version": "1.5.3",
+            "version": "1.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "3b1fc3f0be055baa7c6258b1467849c3e8204eb2"
+                "reference": "f65c239c970e7f072f067ab78646e9f0b2935175"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/3b1fc3f0be055baa7c6258b1467849c3e8204eb2",
-                "reference": "3b1fc3f0be055baa7c6258b1467849c3e8204eb2",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/f65c239c970e7f072f067ab78646e9f0b2935175",
+                "reference": "f65c239c970e7f072f067ab78646e9f0b2935175",
                 "shasum": ""
             },
             "require": {
@@ -64,7 +64,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.5.3"
+                "source": "https://github.com/composer/ca-bundle/tree/1.5.6"
             },
             "funding": [
                 {
@@ -80,7 +80,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-04T10:15:26+00:00"
+            "time": "2025-03-06T14:30:56+00:00"
         },
         {
             "name": "dapphp/securimage",
@@ -249,16 +249,16 @@
         },
         {
             "name": "gettext/gettext",
-            "version": "v5.7.0",
+            "version": "v5.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-gettext/Gettext.git",
-                "reference": "8657e580747bb3baacccdcebe69cac094661e404"
+                "reference": "95820f020e4f2f05e0bbaa5603e4c6ec3edc50f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-gettext/Gettext/zipball/8657e580747bb3baacccdcebe69cac094661e404",
-                "reference": "8657e580747bb3baacccdcebe69cac094661e404",
+                "url": "https://api.github.com/repos/php-gettext/Gettext/zipball/95820f020e4f2f05e0bbaa5603e4c6ec3edc50f1",
+                "reference": "95820f020e4f2f05e0bbaa5603e4c6ec3edc50f1",
                 "shasum": ""
             },
             "require": {
@@ -303,7 +303,7 @@
             "support": {
                 "email": "oom@oscarotero.com",
                 "issues": "https://github.com/php-gettext/Gettext/issues",
-                "source": "https://github.com/php-gettext/Gettext/tree/v5.7.0"
+                "source": "https://github.com/php-gettext/Gettext/tree/v5.7.3"
             },
             "funding": [
                 {
@@ -319,20 +319,20 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2022-07-27T19:54:55+00:00"
+            "time": "2024-12-01T10:18:08+00:00"
         },
         {
             "name": "gettext/languages",
-            "version": "2.10.0",
+            "version": "2.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-gettext/Languages.git",
-                "reference": "4d61d67fe83a2ad85959fe6133d6d9ba7dddd1ab"
+                "reference": "0b0b0851c55168e1dfb14305735c64019732b5f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-gettext/Languages/zipball/4d61d67fe83a2ad85959fe6133d6d9ba7dddd1ab",
-                "reference": "4d61d67fe83a2ad85959fe6133d6d9ba7dddd1ab",
+                "url": "https://api.github.com/repos/php-gettext/Languages/zipball/0b0b0851c55168e1dfb14305735c64019732b5f1",
+                "reference": "0b0b0851c55168e1dfb14305735c64019732b5f1",
                 "shasum": ""
             },
             "require": {
@@ -342,7 +342,8 @@
                 "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.5 || ^8.4"
             },
             "bin": [
-                "bin/export-plural-rules"
+                "bin/export-plural-rules",
+                "bin/import-cldr-data"
             ],
             "type": "library",
             "autoload": {
@@ -381,7 +382,7 @@
             ],
             "support": {
                 "issues": "https://github.com/php-gettext/Languages/issues",
-                "source": "https://github.com/php-gettext/Languages/tree/2.10.0"
+                "source": "https://github.com/php-gettext/Languages/tree/2.12.1"
             },
             "funding": [
                 {
@@ -393,7 +394,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-10-18T15:00:10+00:00"
+            "time": "2025-03-19T11:14:02+00:00"
         },
         {
             "name": "lifo/ip",
@@ -444,29 +445,27 @@
         },
         {
             "name": "maxmind-db/reader",
-            "version": "v1.11.1",
+            "version": "v1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/maxmind/MaxMind-DB-Reader-php.git",
-                "reference": "1e66f73ffcf25e17c7a910a1317e9720a95497c7"
+                "reference": "815939e006b7e68062b540ec9e86aaa8be2b6ce4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/maxmind/MaxMind-DB-Reader-php/zipball/1e66f73ffcf25e17c7a910a1317e9720a95497c7",
-                "reference": "1e66f73ffcf25e17c7a910a1317e9720a95497c7",
+                "url": "https://api.github.com/repos/maxmind/MaxMind-DB-Reader-php/zipball/815939e006b7e68062b540ec9e86aaa8be2b6ce4",
+                "reference": "815939e006b7e68062b540ec9e86aaa8be2b6ce4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2"
             },
             "conflict": {
-                "ext-maxminddb": "<1.11.1,>=2.0.0"
+                "ext-maxminddb": "<1.11.1 || >=2.0.0"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "3.*",
-                "php-coveralls/php-coveralls": "^2.1",
                 "phpstan/phpstan": "*",
-                "phpunit/phpcov": ">=6.0.0",
                 "phpunit/phpunit": ">=8.0.0,<10.0.0",
                 "squizlabs/php_codesniffer": "3.*"
             },
@@ -503,29 +502,29 @@
             ],
             "support": {
                 "issues": "https://github.com/maxmind/MaxMind-DB-Reader-php/issues",
-                "source": "https://github.com/maxmind/MaxMind-DB-Reader-php/tree/v1.11.1"
+                "source": "https://github.com/maxmind/MaxMind-DB-Reader-php/tree/v1.12.1"
             },
-            "time": "2023-12-02T00:09:23+00:00"
+            "time": "2025-05-05T20:56:32+00:00"
         },
         {
             "name": "maxmind/web-service-common",
-            "version": "v0.9.0",
+            "version": "v0.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/maxmind/web-service-common-php.git",
-                "reference": "4dc5a3e8df38aea4ca3b1096cee3a038094e9b53"
+                "reference": "d7c7c42fc31bff26e0ded73a6e187bcfb193f9c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/maxmind/web-service-common-php/zipball/4dc5a3e8df38aea4ca3b1096cee3a038094e9b53",
-                "reference": "4dc5a3e8df38aea4ca3b1096cee3a038094e9b53",
+                "url": "https://api.github.com/repos/maxmind/web-service-common-php/zipball/d7c7c42fc31bff26e0ded73a6e187bcfb193f9c4",
+                "reference": "d7c7c42fc31bff26e0ded73a6e187bcfb193f9c4",
                 "shasum": ""
             },
             "require": {
                 "composer/ca-bundle": "^1.0.3",
                 "ext-curl": "*",
                 "ext-json": "*",
-                "php": ">=7.2"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "3.*",
@@ -554,9 +553,9 @@
             "homepage": "https://github.com/maxmind/web-service-common-php",
             "support": {
                 "issues": "https://github.com/maxmind/web-service-common-php/issues",
-                "source": "https://github.com/maxmind/web-service-common-php/tree/v0.9.0"
+                "source": "https://github.com/maxmind/web-service-common-php/tree/v0.10.0"
             },
-            "time": "2022-03-28T17:43:20+00:00"
+            "time": "2024-11-14T23:14:52+00:00"
         },
         {
             "name": "mrclay/minify",
@@ -610,34 +609,36 @@
             "time": "2017-11-03T21:04:01+00:00"
         },
         {
-            "name": "phpmyadmin/twig-i18n-extension",
-            "version": "v4.0.1",
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.5.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpmyadmin/twig-i18n-extension.git",
-                "reference": "c0d0dd171cd1c7733bf152fd44b61055843df052"
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpmyadmin/twig-i18n-extension/zipball/c0d0dd171cd1c7733bf152fd44b61055843df052",
-                "reference": "c0d0dd171cd1c7733bf152fd44b61055843df052",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
+                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0",
-                "twig/twig": "^1.42.3|^2.0|^3.0"
-            },
-            "require-dev": {
-                "phpmyadmin/coding-standard": "^3.0.0",
-                "phpmyadmin/motranslator": "^5.2",
-                "phpstan/phpstan": "^0.12.66",
-                "phpunit/phpunit": "^7 || ^8 || ^9"
+                "php": ">=8.1"
             },
             "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "PhpMyAdmin\\Twig\\Extensions\\": "src/"
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.5-dev"
                 }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -645,42 +646,51 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
                 },
                 {
-                    "name": "The phpMyAdmin Team",
-                    "email": "developers@phpmyadmin.net",
-                    "homepage": "https://www.phpmyadmin.net/team/"
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Internationalization support for Twig via the gettext library",
-            "keywords": [
-                "gettext",
-                "i18n"
-            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
             "support": {
-                "issues": "https://github.com/phpmyadmin/twig-i18n-extension/issues",
-                "source": "https://github.com/phpmyadmin/twig-i18n-extension"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.1"
             },
-            "time": "2021-06-10T15:53:38+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:20:29+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.27.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a"
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/5bbc823adecdae860bb64756d639ecfec17b050a",
-                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "provide": {
                 "ext-ctype": "*"
@@ -690,12 +700,9 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -729,7 +736,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -745,24 +752,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.27.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534"
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
-                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "ext-iconv": "*",
+                "php": ">=7.2"
             },
             "provide": {
                 "ext-mbstring": "*"
@@ -772,12 +780,9 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -812,7 +817,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -828,118 +833,41 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php72",
-            "version": "v1.27.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "869329b1e9894268a8a61dabb69153029b7a8c97"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/869329b1e9894268a8a61dabb69153029b7a8c97",
-                "reference": "869329b1e9894268a8a61dabb69153029b7a8c97",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php72\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php72/tree/v1.27.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2024-12-23T08:48:59+00:00"
         },
         {
             "name": "twig/twig",
-            "version": "v2.15.4",
+            "version": "v3.21.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "3e059001d6d597dd50ea7c74dd2464b4adea48d3"
+                "reference": "285123877d4dd97dd7c11842ac5fb7e86e60d81d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/3e059001d6d597dd50ea7c74dd2464b4adea48d3",
-                "reference": "3e059001d6d597dd50ea7c74dd2464b4adea48d3",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/285123877d4dd97dd7c11842ac5fb7e86e60d81d",
+                "reference": "285123877d4dd97dd7c11842ac5fb7e86e60d81d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1.3",
+                "php": ">=8.1.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-ctype": "^1.8",
-                "symfony/polyfill-mbstring": "^1.3",
-                "symfony/polyfill-php72": "^1.8"
+                "symfony/polyfill-mbstring": "^1.3"
             },
             "require-dev": {
-                "psr/container": "^1.0",
-                "symfony/phpunit-bridge": "^4.4.9|^5.0.9|^6.0"
+                "phpstan/phpstan": "^2.0",
+                "psr/container": "^1.0|^2.0",
+                "symfony/phpunit-bridge": "^5.4.9|^6.4|^7.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.15-dev"
-                }
-            },
             "autoload": {
-                "psr-0": {
-                    "Twig_": "lib/"
-                },
+                "files": [
+                    "src/Resources/core.php",
+                    "src/Resources/debug.php",
+                    "src/Resources/escaper.php",
+                    "src/Resources/string_loader.php"
+                ],
                 "psr-4": {
                     "Twig\\": "src/"
                 }
@@ -972,7 +900,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v2.15.4"
+                "source": "https://github.com/twigphp/Twig/tree/v3.21.1"
             },
             "funding": [
                 {
@@ -984,7 +912,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-27T12:26:20+00:00"
+            "time": "2025-05-03T07:21:55+00:00"
         }
     ],
     "packages-dev": [],
@@ -994,14 +922,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4",
+        "php": ">=8.1",
         "ext-mbstring": ">=7.4",
         "ext-gd": ">=7.4",
         "ext-pdo": ">=7.4"
     },
     "platform-dev": [],
-    "platform-overrides": {
-        "php": "7.4"
-    },
     "plugin-api-version": "2.3.0"
 }

--- a/inc/display.php
+++ b/inc/display.php
@@ -338,6 +338,7 @@ function embed_html($link) {
 	return 'Embedding error.';
 }
 
+#[AllowDynamicProperties]
 class Post {
 	public function __construct($post, $root=null, $mod=false) {
 		global $config;
@@ -416,6 +417,7 @@ class Post {
 	}
 };
 
+#[AllowDynamicProperties]
 class Thread {
 	public function __construct($post, $root = null, $mod = false, $hr = true) {
 		global $config;

--- a/inc/image.php
+++ b/inc/image.php
@@ -7,7 +7,11 @@
 defined('TINYBOARD') or exit;
 
 class Image {
-	public $src, $format, $image, $size;
+	public string $src;
+	public string|false $format;
+	public ImageBase $image;
+	public object $size;
+
 	public function __construct($src, $format = false, $size = false) {
 		global $config;
 
@@ -101,6 +105,13 @@ class Image {
 }
 
 class ImageGD {
+	public int $width = 0;
+	public int $height = 0;
+	public int $original_width = 0;
+	public int $original_height = 0;
+	public mixed $original = null;
+	public mixed $image = null;
+
 	public function GD_create() {
 		$this->image = imagecreatetruecolor($this->width, $this->height);
 	}
@@ -114,7 +125,9 @@ class ImageGD {
 }
 
 class ImageBase extends ImageGD {
-	public $image, $src, $original, $original_width, $original_height, $width, $height;
+	public string $src = '';
+	public string|false $format = false;
+
 	public function valid() {
 		return (bool)$this->image;
 	}
@@ -233,7 +246,9 @@ class ImageImagick extends ImageBase {
 
 
 class ImageConvert extends ImageBase {
-	public $width, $height, $temp, $gm = false, $gifsicle = false;
+	public ?string $temp = null;
+	public bool $gm = false;
+	public bool $gifsicle = false;
 
 	public function init() {
 		global $config;

--- a/inc/lib/webm/Twig/Cache.php
+++ b/inc/lib/webm/Twig/Cache.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Vichan\Twig\FilesystemCache;
+
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use Twig\Cache\FilesystemCache;
+
+class TinyboardFilesystem extends FilesystemCache
+{
+	private $directory;
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function __construct($directory, $options = 0)
+	{
+		parent::__construct($directory, $options);
+		$this->directory = $directory;
+	}
+
+	/**
+	 * This function was removed in Twig 2.x due to developer views on the Twig library. Who says we can't keep it for ourselves though?
+	 */
+	public function clear()
+	{
+		foreach (new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator($this->directory),
+			RecursiveIteratorIterator::LEAVES_ONLY
+		) as $file) {
+			if ($file->isFile()) {
+				@unlink($file->getPathname());
+			}
+		}
+	}
+}

--- a/inc/lib/webm/Twig/I18nExtension.php
+++ b/inc/lib/webm/Twig/I18nExtension.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Twig I18n extension.
+ *
+ * (c) 2010-2019 Fabien Potencier
+ * (c) 2019-2021 phpMyAdmin contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Vichan\Twig\Extensions;
+
+use Vichan\Twig\Extensions\TokenParser\TransTokenParser;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+use function dgettext;
+use function gettext;
+
+class I18nExtension extends AbstractExtension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getTokenParsers()
+    {
+        return [new TransTokenParser()];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilters()
+    {
+        return [
+            new TwigFilter('trans', $this->translate(...)), /* Note, the filter does not handle plurals */
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'i18n';
+    }
+
+    /**
+     * Translate a GetText string via filter
+     *
+     * @param string      $message The message to translate
+     * @param string|null $domain  The GetText domain
+     */
+    public function translate(string $message, string|null $domain = null): string
+    {
+        /* If we don't have a domain, assume we're just using the default */
+        if ($domain === null) {
+            return gettext($message);
+        }
+
+        /* Otherwise specify where the message comes from */
+        return dgettext($domain, $message);
+    }
+}

--- a/inc/lib/webm/Twig/Node/I18nNode.php
+++ b/inc/lib/webm/Twig/Node/I18nNode.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Twig I18n extension.
+ *
+ * (c) 2025 phpMyAdmin contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Vichan\Twig\Extensions\Node;
+
+use Twig\Attribute\YieldReady;
+use Twig\Node\Node;
+
+/**
+ * Represents a single node
+ */
+#[YieldReady]
+final class I18nNode extends Node
+{
+    /**
+     * @param Node|null            $node       A single node
+     * @param array<string, mixed> $attributes An array of attributes (should not be nodes)
+     * @param int                  $lineno     The line number
+     */
+    public function __construct(Node|null $node, array $attributes, int $lineno)
+    {
+        parent::__construct($node instanceof \Twig\Node\Node ? [$node] : [], $attributes, $lineno);
+    }
+}

--- a/inc/lib/webm/Twig/Node/TransNode.php
+++ b/inc/lib/webm/Twig/Node/TransNode.php
@@ -1,0 +1,305 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Twig I18n extension.
+ *
+ * (c) 2010-2019 Fabien Potencier
+ * (c) 2019-2021 phpMyAdmin contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Vichan\Twig\Extensions\Node;
+
+use Twig\Attribute\YieldReady;
+use Twig\Compiler;
+use Twig\Node\CheckToStringNode;
+use Twig\Node\Expression\AbstractExpression;
+use Twig\Node\Expression\ConstantExpression;
+use Twig\Node\Expression\FilterExpression;
+use Twig\Node\Expression\Variable\ContextVariable;
+use Twig\Node\Expression\Variable\LocalVariable;
+use Twig\Node\Node;
+use Twig\Node\PrintNode;
+use Twig\Node\TextNode;
+
+use function array_merge;
+use function count;
+use function sprintf;
+use function str_replace;
+use function trim;
+
+/**
+ * Represents a trans node.
+ *
+ * Author Fabien Potencier <fabien.potencier@symfony-project.com>
+ */
+#[YieldReady]
+class TransNode extends Node
+{
+    /**
+     * The label for gettext notes to be exported
+     */
+    public static string $notesLabel = '// notes: ';
+
+    /**
+     * Enable MoTranslator functions
+     */
+    public static bool $enableMoTranslator = false;
+
+    /**
+     * Enable calls to addDebugInfo
+     */
+    public static bool $enableAddDebugInfo = false;
+
+    /**
+     * Enables context functions usage
+     */
+    public static bool $hasContextFunctions = false;
+
+    /** @phpstan-ignore constructor.unusedParameter */
+    public function __construct(
+        Node $body,
+        Node|null $plural,
+        AbstractExpression|null $count,
+        Node|null $context = null,
+        Node|null $notes = null,
+        Node|null $domain = null,
+        int $lineno = 0,
+    ) {
+        $nodes = ['body' => $body];
+        if ($count instanceof \Twig\Node\Expression\AbstractExpression) {
+            $nodes['count'] = $count;
+        }
+
+        if ($plural instanceof \Twig\Node\Node) {
+            $nodes['plural'] = $plural;
+        }
+
+        if ($notes instanceof \Twig\Node\Node) {
+            $nodes['notes'] = $notes;
+        }
+
+        if ($domain instanceof \Twig\Node\Node) {
+            $nodes['domain'] = $domain;
+        }
+
+        if ($context instanceof \Twig\Node\Node) {
+            $nodes['context'] = $context;
+        }
+
+        parent::__construct($nodes, [], $lineno);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function compile(Compiler $compiler)
+    {
+        if (self::$enableAddDebugInfo) {
+            $compiler->addDebugInfo($this);
+        }
+
+        [$msg, $vars] = $this->compileString($this->getNode('body'));
+
+        $hasPlural = $this->hasNode('plural');
+
+        if ($hasPlural) {
+            [$msg1, $vars1] = $this->compileString($this->getNode('plural'));
+
+            $vars = array_merge($vars, $vars1);
+        }
+
+        $hasDomain = $this->hasNode('domain');
+        $hasContext = $this->hasNode('context');
+
+        $function = $this->getTransFunction($hasPlural, $hasContext, $hasDomain);
+
+        if ($this->hasNode('notes')) {
+            $message = trim((string) $this->getNode('notes')->getAttribute('data'));
+
+            // line breaks are not allowed because we want a single line comment
+            $message = str_replace(["\n", "\r"], ' ', $message);
+            $compiler->raw(static::$notesLabel . $message . "\n");
+        }
+
+        if ($vars) {
+            $compiler->raw('yield strtr(' . $function . '(');
+
+            if ($hasDomain) {
+                [$domain] = $this->compileString($this->getNode('domain'));
+                $compiler
+                    ->subcompile($domain)
+                    ->raw(', ');
+            }
+
+            if ($hasContext && (static::$hasContextFunctions || static::$enableMoTranslator)) {
+                [$context] = $this->compileString($this->getNode('context'));
+                $compiler
+                    ->subcompile($context)
+                    ->raw(', ');
+            }
+
+            $compiler
+                ->subcompile($msg);
+
+            if ($hasPlural) {
+                $compiler
+                    ->raw(', ')
+                    ->subcompile($msg1)
+                    ->raw(', abs(')
+                    ->subcompile($this->getNode('count'))
+                    ->raw(')');
+            }
+
+            $compiler->raw('), array(');
+
+            foreach ($vars as $var) {
+                $attributeName = $var->getAttribute('name');
+                if ($attributeName === 'count') {
+                    $compiler
+                        ->string('%count%')
+                        ->raw(' => abs(')
+                        ->subcompile($this->getNode('count'))
+                        ->raw('), ');
+                } else {
+                    $compiler
+                        ->string('%' . $attributeName . '%')
+                        ->raw(' => ')
+                        ->subcompile($var)
+                        ->raw(', ');
+                }
+            }
+
+            $compiler->raw("));\n");
+        } else {
+            $compiler->raw('yield ' . $function . '(');
+
+            if ($hasDomain) {
+                [$domain] = $this->compileString($this->getNode('domain'));
+                $compiler
+                    ->subcompile($domain)
+                    ->raw(', ');
+            }
+
+            if ($hasContext && (static::$hasContextFunctions || static::$enableMoTranslator)) {
+                [$context] = $this->compileString($this->getNode('context'));
+                $compiler
+                    ->subcompile($context)
+                    ->raw(', ');
+            }
+
+            $compiler
+                ->subcompile($msg);
+
+            if ($hasPlural) {
+                $compiler
+                    ->raw(', ')
+                    ->subcompile($msg1)
+                    ->raw(', abs(')
+                    ->subcompile($this->getNode('count'))
+                    ->raw(')');
+            }
+
+            $compiler->raw(");\n");
+        }
+    }
+
+    /**
+     * Keep this method protected instead of private some implementations may use it
+     *
+     * @psalm-return array{Node, list<ContextVariable>}
+     */
+    protected function compileString(Node $body): array
+    {
+        if ($body instanceof ContextVariable || $body instanceof ConstantExpression || $body instanceof LocalVariable) {
+            return [$body, []];
+        }
+
+        $vars = [];
+        if (count($body) > 0) {
+            $msg = '';
+
+            foreach ($body as $node) {
+                if ($node instanceof PrintNode) {
+                    $n = $node->getNode('expr');
+                    while ($n instanceof FilterExpression) {
+                        $n = $n->getNode('node');
+                    }
+
+                    while ($n instanceof CheckToStringNode) {
+                        $n = $n->getNode('expr');
+                    }
+
+                    $attributeName = $n->getAttribute('name');
+                    $msg .= sprintf('%%%s%%', $attributeName);
+                    $vars[] = new ContextVariable($attributeName, $n->getTemplateLine());
+                } else {
+                    /** @phpstan-var TextNode $node */
+                    $msg .= $node->getAttribute('data');
+                }
+            }
+        } else {
+            $msg = $body->getAttribute('data');
+        }
+
+        return [new I18nNode(new ConstantExpression(trim((string) $msg), $body->getTemplateLine()), [], 0), $vars];
+    }
+
+    /**
+     * Keep this protected to allow people to override it with their own logic
+     */
+    protected function getTransFunction(bool $hasPlural, bool $hasContext, bool $hasDomain): string
+    {
+        $functionPrefix = '';
+
+        if (static::$enableMoTranslator) {
+            // The functions are prefixed with an underscore
+            $functionPrefix = '_';
+        }
+
+        // If it has not context function support or not MoTranslator
+        if (! static::$hasContextFunctions && ! static::$enableMoTranslator) {
+            // Not found on native PHP: dnpgettext, npgettext, dpgettext, pgettext
+            // No domain plural context support
+            // No domain context support
+            // No context support
+            // No plural context support
+
+            if ($hasDomain) {
+                // dngettext($domain, $msgid, $msgidPlural, $number);
+                // dgettext($domain, $msgid);
+                return $functionPrefix . ($hasPlural ? 'dngettext' : 'dgettext');
+            }
+
+            // ngettext($msgid, $msgidPlural, $number);
+            // gettext($msgid);
+            return $functionPrefix . ($hasPlural ? 'ngettext' : 'gettext');
+        }
+
+        if ($hasDomain) {
+            if ($hasPlural) {
+                // dnpgettext($domain, $msgctxt, $msgid, $msgidPlural, $number);
+                // dngettext($domain, $msgid, $msgidPlural, $number);
+                return $functionPrefix . ($hasContext ? 'dnpgettext' : 'dngettext');
+            }
+
+            // dpgettext($domain, $msgctxt, $msgid);
+            // dgettext($domain, $msgid);
+            return $functionPrefix . ($hasContext ? 'dpgettext' : 'dgettext');
+        }
+
+        if ($hasPlural) {
+            // npgettext($msgctxt, $msgid, $msgidPlural, $number);
+            // ngettext($msgid, $msgidPlural, $number);
+            return $functionPrefix . ($hasContext ? 'npgettext' : 'ngettext');
+        }
+
+        // pgettext($msgctxt, $msgid);
+        // gettext($msgid);
+        return $functionPrefix . ($hasContext ? 'pgettext' : 'gettext');
+    }
+}

--- a/inc/lib/webm/Twig/TinyboardExtension.php
+++ b/inc/lib/webm/Twig/TinyboardExtension.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Vichan\Twig\Extensions;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+
+class Tinyboard extends AbstractExtension
+{
+	/**
+	* Returns a list of filters to add to the existing list.
+	*
+	* @return array An array of filters
+	*/
+	public function getFilters()
+	{
+		return array(
+			new TwigFilter('filesize', 'format_bytes'),
+			new TwigFilter('truncate', 'twig_truncate_filter'),
+			new TwigFilter('truncate_body', 'truncate'),
+			new TwigFilter('truncate_filename', 'twig_filename_truncate_filter'),
+			new TwigFilter('extension', 'twig_extension_filter'),
+			new TwigFilter('sprintf', 'sprintf'),
+			new TwigFilter('capcode', 'capcode'),
+			new TwigFilter('remove_modifiers', 'remove_modifiers'),
+			new TwigFilter('hasPermission', 'twig_hasPermission_filter'),
+			new TwigFilter('date', 'twig_date_filter'),
+			new TwigFilter('poster_id', 'poster_id'),
+			new TwigFilter('count', 'count'),
+			new TwigFilter('ago', 'Vichan\Functions\Format\ago'),
+			new TwigFilter('until', 'Vichan\Functions\Format\until'),
+			new TwigFilter('push', 'twig_push_filter'),
+			new TwigFilter('bidi_cleanup', 'bidi_cleanup'),
+			new TwigFilter('addslashes', 'addslashes'),
+			new TwigFilter('cloak_ip', 'cloak_ip'),
+			new TwigFilter('cloak_mask', 'cloak_mask'),
+		);
+	}
+
+	/**
+	* Returns a list of functions to add to the existing list.
+	*
+	* @return array An array of filters
+	*/
+	public function getFunctions()
+	{
+		return array(
+			new TwigFunction('time', 'time'),
+			new TwigFunction('floor', 'floor'),
+			new TwigFunction('hiddenInputs', 'hiddenInputs'),
+			new TwigFunction('hiddenInputsHash', 'hiddenInputsHash'),
+			new TwigFunction('ratio', 'twig_ratio_function'),
+			new TwigFunction('secure_link_confirm', 'twig_secure_link_confirm'),
+			new TwigFunction('secure_link', 'twig_secure_link'),
+			new TwigFunction('link_for', 'link_for')
+		);
+	}
+
+	/**
+	* Returns the name of the extension.
+	*
+	* @return string The extension name
+	*/
+	public function getName()
+	{
+		return 'tinyboard';
+	}
+}

--- a/inc/lib/webm/Twig/TinyboardExtension.php
+++ b/inc/lib/webm/Twig/TinyboardExtension.php
@@ -6,7 +6,7 @@ use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
 
-class Tinyboard extends AbstractExtension
+class TinyboardExtension extends AbstractExtension
 {
 	/**
 	* Returns a list of filters to add to the existing list.

--- a/inc/lib/webm/Twig/TokenParser/TokenParser.php
+++ b/inc/lib/webm/Twig/TokenParser/TokenParser.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Twig I18n extension.
+ *
+ * (c) 2010-2019 Fabien Potencier
+ * (c) 2019-2021 phpMyAdmin contributors
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Vichan\Twig\Extensions\TokenParser;
+
+use Vichan\Twig\Extensions\Node\I18nNode;
+use Vichan\Twig\Extensions\Node\TransNode;
+use Twig\Error\SyntaxError;
+use Twig\Node\Expression\AbstractExpression;
+use Twig\Node\Expression\Variable\ContextVariable;
+use Twig\Node\Node;
+use Twig\Node\PrintNode;
+use Twig\Node\TextNode;
+use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
+
+class TransTokenParser extends AbstractTokenParser
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function parse(Token $token)
+    {
+        [
+            $body,
+            $plural,
+            $count,
+            $context,
+            $notes,
+            $domain,
+            $lineno,
+            $tag,
+        ] = $this->preParse($token);
+
+        return new TransNode($body, $plural, $count, $context, $notes, $domain, $lineno, $tag);
+    }
+
+    /** @psalm-return array{Node, Node|null, AbstractExpression|null, Node|null, Node|null, Node|null, int, string} */
+    protected function preParse(Token $token): array
+    {
+        $lineno = $token->getLine();
+        $stream = $this->parser->getStream();
+        $domain = null;
+        $count = null;
+        $plural = null;
+        $notes = null;
+        $context = null;
+
+        /* If we aren't closing the block, do we have a domain? */
+        if ($stream->test(Token::NAME_TYPE)) {
+            $stream->expect(Token::NAME_TYPE, 'from');
+            $domain = $this->parser->parseExpression();
+        }
+
+        if (! $stream->test(Token::BLOCK_END_TYPE)) {
+            $body = $this->parser->parseExpression();
+        } else {
+            $stream->expect(Token::BLOCK_END_TYPE);
+            $body = $this->parser->subparse($this->decideForFork(...));
+            $next = $stream->next()->getValue();
+
+            if ($next === 'plural') {
+                $count = $this->parser->parseExpression();
+                $stream->expect(Token::BLOCK_END_TYPE);
+                $plural = $this->parser->subparse($this->decideForFork(...));
+                $next = $stream->next()->getValue();
+                if ($next === 'notes') {
+                    $stream->expect(Token::BLOCK_END_TYPE);
+                    $notes = $this->parser->subparse($this->decideForEnd(...), true);
+                } elseif ($next === 'context') {
+                    $stream->expect(Token::BLOCK_END_TYPE);
+                    $context = $this->parser->subparse($this->decideForEnd(...), true);
+                }
+            } elseif ($next === 'context') {
+                $stream->expect(Token::BLOCK_END_TYPE);
+                $context = $this->parser->subparse($this->decideForEnd(...), true);
+            } elseif ($next === 'notes') {
+                $stream->expect(Token::BLOCK_END_TYPE);
+                $notes = $this->parser->subparse($this->decideForEnd(...), true);
+            }
+        }
+
+        $stream->expect(Token::BLOCK_END_TYPE);
+
+        $this->checkTransString($body, $lineno);
+
+        if ($notes instanceof TextNode) {
+            // Don't use TextNode for $notes to avoid it getting merged with $body when optimizing.
+            $notes = new I18nNode(null, ['data' => $notes->getAttribute('data')], $notes->getTemplateLine());
+        }
+
+        if ($context instanceof TextNode) {
+            // Don't use TextNode for $context to avoid it getting merged with $body when optimizing.
+            $context = new I18nNode(null, ['data' => $context->getAttribute('data')], $context->getTemplateLine());
+        }
+
+        return [$body, $plural, $count, $context, $notes, $domain, $lineno, $this->getTag()];
+    }
+
+    public function decideForFork(Token $token): bool
+    {
+        return $token->test(['plural', 'context', 'notes', 'endtrans']);
+    }
+
+    public function decideForEnd(Token $token): bool
+    {
+        return $token->test('endtrans');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTag()
+    {
+        return 'trans';
+    }
+
+    /** @throws SyntaxError */
+    protected function checkTransString(Node $body, int $lineno): void
+    {
+        foreach ($body as $node) {
+            if (
+                $node instanceof TextNode
+                ||
+                ($node instanceof PrintNode && $node->getNode('expr') instanceof ContextVariable)
+            ) {
+                continue;
+            }
+
+            throw new SyntaxError(
+                'The text to be translated with "trans" can only contain references to simple variables.',
+                $lineno,
+            );
+        }
+    }
+}

--- a/inc/template.php
+++ b/inc/template.php
@@ -18,14 +18,14 @@ function load_twig() {
 	$twig = new Twig\Environment($loader, array(
 		'autoescape' => false,
 		'cache' => is_writable('templates/') || (is_dir($cache_dir) && is_writable($cache_dir)) ?
-			new TinyboardTwigCache($cache_dir) : false,
+			new Vichan\Twig\FilesystemCache\TinyboardFilesystem($cache_dir) : false,
 		'debug' => $config['debug'],
 		'auto_reload' => $config['twig_auto_reload']
 	));
 	if ($config['debug'])
 		$twig->addExtension(new \Twig\Extension\DebugExtension());
-	$twig->addExtension(new Tinyboard());
-	$twig->addExtension(new PhpMyAdmin\Twig\Extensions\I18nExtension());
+	$twig->addExtension(new Vichan\Twig\Extensions\TinyboardExtension());
+	$twig->addExtension(new Vichan\Twig\Extensions\I18nExtension());
 }
 
 function Element($templateFile, array $options) {
@@ -66,94 +66,6 @@ function Element($templateFile, array $options) {
 		return $body;
 	} else {
 		throw new Exception("Template file '{$templateFile}' does not exist or is empty in '{$config['dir']['template']}'!");
-	}
-}
-
-class TinyboardTwigCache extends Twig\Cache\FilesystemCache {
-	private string $directory;
-
-	public function __construct(string $directory) {
-		parent::__construct($directory);
-		$this->directory = $directory;
-	}
-
-	/**
-	 * This function was removed in Twig 2.x due to developer views on the Twig library.
-	 * Who says we can't keep it for ourselves though?
-	 */
-	public function clear() {
-		$iter = new RecursiveIteratorIterator(
-			new RecursiveDirectoryIterator($this->directory),
-			RecursiveIteratorIterator::LEAVES_ONLY
-		);
-
-		foreach ($iter as $file) {
-			if ($file->isFile()) {
-				@unlink($file->getPathname());
-			}
-		}
-	}
-}
-
-class Tinyboard extends Twig\Extension\AbstractExtension
-{
-	/**
-	* Returns a list of filters to add to the existing list.
-	*
-	* @return array An array of filters
-	*/
-	public function getFilters()
-	{
-		return array(
-			new Twig\TwigFilter('filesize', 'format_bytes'),
-			new Twig\TwigFilter('truncate', 'twig_truncate_filter'),
-			new Twig\TwigFilter('truncate_body', 'truncate'),
-			new Twig\TwigFilter('truncate_filename', 'twig_filename_truncate_filter'),
-			new Twig\TwigFilter('extension', 'twig_extension_filter'),
-			new Twig\TwigFilter('sprintf', 'sprintf'),
-			new Twig\TwigFilter('capcode', 'capcode'),
-			new Twig\TwigFilter('remove_modifiers', 'remove_modifiers'),
-			new Twig\TwigFilter('hasPermission', 'twig_hasPermission_filter'),
-			new Twig\TwigFilter('date', 'twig_date_filter'),
-			new Twig\TwigFilter('poster_id', 'poster_id'),
-			new Twig\TwigFilter('count', 'count'),
-			new Twig\TwigFilter('ago', 'Vichan\Functions\Format\ago'),
-			new Twig\TwigFilter('until', 'Vichan\Functions\Format\until'),
-			new Twig\TwigFilter('push', 'twig_push_filter'),
-			new Twig\TwigFilter('bidi_cleanup', 'bidi_cleanup'),
-			new Twig\TwigFilter('addslashes', 'addslashes'),
-			new Twig\TwigFilter('cloak_ip', 'cloak_ip'),
-			new Twig\TwigFilter('cloak_mask', 'cloak_mask'),
-		);
-	}
-
-	/**
-	* Returns a list of functions to add to the existing list.
-	*
-	* @return array An array of filters
-	*/
-	public function getFunctions()
-	{
-		return array(
-			new Twig\TwigFunction('time', 'time'),
-			new Twig\TwigFunction('floor', 'floor'),
-			new Twig\TwigFunction('hiddenInputs', 'hiddenInputs'),
-			new Twig\TwigFunction('hiddenInputsHash', 'hiddenInputsHash'),
-			new Twig\TwigFunction('ratio', 'twig_ratio_function'),
-			new Twig\TwigFunction('secure_link_confirm', 'twig_secure_link_confirm'),
-			new Twig\TwigFunction('secure_link', 'twig_secure_link'),
-			new Twig\TwigFunction('link_for', 'link_for')
-		);
-	}
-
-	/**
-	* Returns the name of the extension.
-	*
-	* @return string The extension name
-	*/
-	public function getName()
-	{
-		return 'tinyboard';
 	}
 }
 

--- a/search.php
+++ b/search.php
@@ -149,7 +149,7 @@
 		}
 
 		$temp = '';
-		while($post = $query->fetch()) {
+		while($post = $query->fetch(PDO::FETCH_ASSOC)) {
 			if(!$post['thread']) {
 				$po = new Thread($post);
 			} else {

--- a/templates/banned.html
+++ b/templates/banned.html
@@ -1,5 +1,3 @@
-{% apply spaceless %}
-{# Automatically removes unnecessary whitespace #}
 <div class="ban">
 	{% if ban.expires and time() >= ban.expires %}
 		<h2>{% trans %}You were banned! ;_;{% endtrans %}</h2>
@@ -142,4 +140,3 @@
 		{% endif %}
 	{% endif %}
 </div>
-{% endapply %}

--- a/templates/notbanned.html
+++ b/templates/notbanned.html
@@ -1,7 +1,4 @@
-{% apply spaceless %}
-{# Automatically removes unnecessary whitespace #}
 <div class="ban">
   <h2>You are not banned!</h2>
   <p class="reason">Well done on not being terrible!</p>
 </div>
-{% endapply %}

--- a/templates/post/time.html
+++ b/templates/post/time.html
@@ -1,1 +1,1 @@
-<time datetime="{{ post.time|date('Y-m-d\\TH:i:s\Z') }}" title="{{ post.time|date('Y-m-d\\TH:i:s\Z') }}">{{ post.time|date(config.post_date) }}</time>
+<time datetime="{{ post.time|date('Y-m-d\\TH:i:s\\Z') }}" title="{{ post.time|date('Y-m-d\\TH:i:s\\Z') }}">{{ post.time|date(config.post_date) }}</time>

--- a/templates/post_reply.html
+++ b/templates/post_reply.html
@@ -1,5 +1,3 @@
-{% apply spaceless %}
-{# tabs and new lines will be ignored #}
 <div class="post reply" id="reply_{{ post.id }}" data-board="{{ board.uri }}">
 	<p class="intro">
 		<label for="delete_{{ post.id }}">
@@ -23,11 +21,10 @@
 		{% include 'post/fileinfo.html' %}
 	</div>
 	<div class="body" {% if post.files|length > 1 %}style="clear:both"{% endif %}>
-		{% endapply %}{% if index %}{{ post.body|truncate_body(post.link) }}{% else %}{{ post.body }}{% endif %}{% apply spaceless %}
+		{% if index %}{{ post.body|truncate_body(post.link) }}{% else %}{{ post.body }}{% endif %}
 		{% if post.modifiers['ban message'] %}
 			{{ config.mod.ban_message|sprintf(post.modifiers['ban message']) }}
 		{% endif %}
 	</div>
 </div>
 <br/>
-{% endapply %}

--- a/templates/post_thread.html
+++ b/templates/post_thread.html
@@ -1,4 +1,3 @@
-{% apply spaceless %}
 {# tabs and new lines will be ignored #}
 
 <div class="thread" id="thread_{{ post.id }}" data-board="{{ board.uri }}">
@@ -67,7 +66,7 @@
 		{% include 'post/post_controls.html' %}
 	</div>
 	<div class="body">
-		{% endapply %}{% if index %}{{ post.body|truncate_body(post.link) }}{% else %}{{ post.body }}{% endif %}{% apply spaceless %}
+		{% if index %}{{ post.body|truncate_body(post.link) }}{% else %}{{ post.body }}{% endif %}
 		{% if post.modifiers['ban message'] %}
 			{{ config.mod.ban_message|sprintf(post.modifiers['ban message']) }}
 		{% endif %}
@@ -102,4 +101,3 @@
 {% endfor %}
 <br class="clear"/>{% if hr %}<hr/>{% endif %}
 </div>
-{% endapply %}

--- a/templates/post_thread_fileboard.html
+++ b/templates/post_thread_fileboard.html
@@ -1,4 +1,3 @@
-{% apply spaceless %}
 {# tabs and new lines will be ignored #}
 
 {# we are intentionally breaking the thread_ID convention: the jses need to handle this case differently #}
@@ -39,4 +38,3 @@
     <a href="{{ post.root }}{{ board.dir }}{{ config.dir.res }}{{ link_for(post) }}">[{% trans %}Reply{% endtrans %}]</a>
 
 </tr>
-{% endapply %}

--- a/templates/themes/basic/index.html
+++ b/templates/themes/basic/index.html
@@ -1,4 +1,3 @@
-{% apply spaceless %}
 <!doctype html>
 <html>
 <head>
@@ -40,4 +39,3 @@
 		{% include 'footer.html' %}
 </body>
 </html>
-{% endapply %}

--- a/templates/themes/catalog/catalog.html
+++ b/templates/themes/catalog/catalog.html
@@ -1,4 +1,3 @@
-{% apply spaceless %}
 <!doctype html>
 <html>
 <head>
@@ -92,4 +91,3 @@
 	{% endverbatim %}</script>
 </body>
 </html>
-{% endapply %}

--- a/templates/themes/categories/news.html
+++ b/templates/themes/categories/news.html
@@ -1,4 +1,3 @@
-{% apply spaceless %}
 <!doctype html>
 <html>
 <head>
@@ -34,4 +33,3 @@
 		{% include 'footer.html' %}
 </body>
 </html>
-{% endapply %}

--- a/templates/themes/categories/sidebar.html
+++ b/templates/themes/categories/sidebar.html
@@ -1,4 +1,3 @@
-{% apply spaceless %}
 <!doctype html>
 <html>
 <head>
@@ -51,4 +50,3 @@
 	{% endfor %}
 </body>
 </html>
-{% endapply %}

--- a/templates/themes/frameset/news.html
+++ b/templates/themes/frameset/news.html
@@ -1,4 +1,3 @@
-{% apply spaceless %}
 <!doctype html>
 <html>
 <head>
@@ -33,4 +32,3 @@
 		{% include 'footer.html' %}
 </body>
 </html>
-{% endapply %}

--- a/templates/themes/frameset/sidebar.html
+++ b/templates/themes/frameset/sidebar.html
@@ -1,4 +1,3 @@
-{% apply spaceless %}
 <!doctype html>
 <html>
 <head>
@@ -38,4 +37,3 @@
 	</fieldset>
 </body>
 </html>
-{% endapply %}

--- a/templates/themes/index/index.html
+++ b/templates/themes/index/index.html
@@ -1,4 +1,3 @@
-{% apply spaceless %}
 <!doctype html>
 <html>
 <head>
@@ -114,4 +113,3 @@
 	
 </body>
 </html>
-{% endapply %}

--- a/templates/themes/recent/recent.html
+++ b/templates/themes/recent/recent.html
@@ -1,4 +1,3 @@
-{% apply spaceless %}
 <!doctype html>
 <html>
 <head>
@@ -60,4 +59,3 @@
 
 </body>
 </html>
-{% endapply %}

--- a/templates/themes/ukko/theme.php
+++ b/templates/themes/ukko/theme.php
@@ -46,7 +46,7 @@
 
 			$count = 0;
 			$threads = array();
-			while($post = $query->fetch()) {
+			while($post = $query->fetch(PDO::FETCH_ASSOC)) {
 
 				if(!isset($threads[$post['board']])) {
 					$threads[$post['board']] = 1;
@@ -64,7 +64,7 @@
 					$posts->execute() or error(db_error($posts));
 					
 					$num_images = 0;
-					while ($po = $posts->fetch()) {
+					while ($po = $posts->fetch(PDO::FETCH_ASSOC)) {
 						if ($po['files'])
 							$num_images++;
 						


### PR DESCRIPTION
PR to bump php version and twig.

- Support for php8.2.
- Support for new twig.
- Change securimage to a fork.
- Hacky fixes to report with long text.
- Proper organization of twig extensions.
- Twig templates changes [(spaceless filter was nuked for a more granular approach) ](https://twig.symfony.com/doc/3.x/templates.html#templates-whitespace-control).
- I18n extension was patched and imported because php-my-admin is planning to archived.

There's some concerns, mainly:
- Twig versions requires >=8.1.
- Display.php is not fit, so there's a decorator for the time being. #[AllowDynamicProperties]