### PR TITLE
URL unshortener scanner should only download headers.

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -2961,6 +2961,7 @@ function trace_url($url) {
 		CURLOPT_RETURNTRANSFER => TRUE,
 		CURLOPT_SSL_VERIFYHOST => FALSE, // suppress certain SSL errors
 		CURLOPT_SSL_VERIFYPEER => FALSE,
+		CURLOPT_NOBODY => TRUE, // only scan the headers
 		CURLOPT_TIMEOUT => 30,
 	));
 	curl_exec($ch);


### PR DESCRIPTION
Prevent the url unshortener feature from causing CURL to needlessly download entire page bodies when scanning for url shorteners. This could cause crashing on massive links, such as links to abnormally large images.